### PR TITLE
changed links and captions in "Help" menu to github pages

### DIFF
--- a/Chummer/code/frmMain.cs
+++ b/Chummer/code/frmMain.cs
@@ -134,12 +134,12 @@ namespace Chummer
 
 		private void contentsToolStripMenuItem_Click(object sender, EventArgs e)
 		{
-			System.Diagnostics.Process.Start("http://www.chummergen.com/chummer/wiki/");
+			System.Diagnostics.Process.Start("https://github.com/JonasTrampe/ChummerGenSR4");
 		}
 
 		private void mnuHelpDumpshock_Click(object sender, EventArgs e)
 		{
-			System.Diagnostics.Process.Start("https://github.com/Agorath/ChummerGenSR4/issues");
+			System.Diagnostics.Process.Start("https://github.com/JonasTrampe/ChummerGenSR4/issues");
 		}
 
 		private void mnuFilePrintMultiple_Click(object sender, EventArgs e)

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -557,7 +557,7 @@
 		</string>
 		<string>
 			<key>Menu_Main_ChummerWiki</key>
-			<text>Chummer Wiki</text>
+			<text>Github Repo</text>
 		</string>
 		<string>
 			<key>Menu_Main_RevisionHistory</key>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-945</version>
+	<version>-946</version>
 	<name>Deutsch (DE)</name>
 	<strings>
 		<string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -618,7 +618,7 @@
 		</string>
 		<string>
 			<key>Menu_Main_ChummerWiki</key>
-			<text>Chummer Wiki</text>
+			<text>Github Repo</text>
 		</string>
 		<string>
 			<key>Menu_Main_RevisionHistory</key>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-905</version>
+	<version>-906</version>
 	<name>English (US)</name>
 	<strings>
 		<!-- Common Strings -->

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -614,7 +614,7 @@
 		</string>
 		<string>
 			<key>Menu_Main_ChummerWiki</key>
-			<text>&amp;Wiki de Chummer (anglais)</text>
+			<text>Github Repo (anglais)</text>
 		</string>
 		<string>
 			<key>Menu_Main_RevisionHistory</key>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-950</version>
+	<version>-951</version>
 	<name>Français</name>
 	<strings>
 		<!-- Common Strings -->

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -620,7 +620,7 @@
 		</string>
 		<string>
 			<key>Menu_Main_ChummerWiki</key>
-			<text>Chummer Wiki</text>
+			<text>Github Repo</text>
 		</string>
 		<string>
 			<key>Menu_Main_RevisionHistory</key>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -2,7 +2,7 @@
 <!-- この言語ファイルは AhonokoP が作成しました。連絡を取りたいときは"Dumpshock Forum"でAhonokoPにメッセージを送ってください -->
 <!-- Translated by AhonokoP. Contact me at "Dumpshock Forum" -->
 <chummer>
-	<version>-996</version>
+	<version>-997</version>
 	<name>日本語 (JP)</name>
 	<strings>
 		<!-- Common Strings -->


### PR DESCRIPTION
- renamed "Chummer Wiki" to "Github Repo" and linked it to "https://github.com/JonasTrampe/ChummerGenSR4"
- linked "Issue Tracker" to "https://github.com/JonasTrampe/ChummerGenSR4/issues"

Fixes #20 