### PR TITLE
Version character data and refresh XML improvements

### DIFF
--- a/Chummer/code/clsCharacter.cs
+++ b/Chummer/code/clsCharacter.cs
@@ -46,6 +46,8 @@ namespace Chummer
 	/// </summary>
 	public class Character
 	{
+		public const int CurrentDataVersion = 1;
+		private int _intDataVersion;
 		private readonly ImprovementManager _objImprovementManager;
 		private readonly CharacterOptions _objOptions = new CharacterOptions();
 		private CommonFunctions _commonFunctions;
@@ -240,6 +242,8 @@ namespace Chummer
 
 			// <appversion />
 			objWriter.WriteElementString("appversion", Application.ProductVersion.ToString().Replace("0.0.0.", string.Empty));
+			// <dataversion />
+			objWriter.WriteElementString("dataversion", CurrentDataVersion.ToString());
 			// <gameedition />
 			objWriter.WriteElementString("gameedition", "SR4");
 
@@ -731,6 +735,10 @@ namespace Chummer
 			}
 
 			ResetCharacter();
+
+			_intDataVersion = 0;
+			if (objXmlCharacter["dataversion"] != null)
+				Int32.TryParse(objXmlCharacter["dataversion"].InnerText, out _intDataVersion);
 
 			// Get the game edition of the file if possible and make sure it's intended to be used with this version of the application.
 			try
@@ -1495,6 +1503,16 @@ namespace Chummer
 				Save();
 
 			return true;
+		}
+
+		public void MarkDataVersionCurrent()
+		{
+			_intDataVersion = CurrentDataVersion;
+		}
+
+		public bool NeedsDataUpdate
+		{
+			get { return _intDataVersion < CurrentDataVersion; }
 		}
 
 		/// <summary>

--- a/Chummer/code/clsUnique.cs
+++ b/Chummer/code/clsUnique.cs
@@ -2500,7 +2500,7 @@ namespace Chummer
 						// Improvement for an individual Skill.
 						if (!_blnExoticSkill)
 						{
-							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == MetaBase || objImprovement.ImprovedName == _strName))
+							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == _strName || (_isMeta && objImprovement.ImprovedName == MetaBase)))
 								intModifier += objImprovement.Value;
 						}
 						else
@@ -2558,7 +2558,7 @@ namespace Chummer
 						// Improvement for an individual Skill.
 						if (!_blnExoticSkill)
 						{
-							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == MetaBase || objImprovement.ImprovedName == _strName))
+							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == _strName || (_isMeta && objImprovement.ImprovedName == MetaBase)))
 							{
 								if (objImprovement.UniqueName != "")
 								{
@@ -2733,7 +2733,7 @@ namespace Chummer
 						// Improvement for an individual Skill.
 						if (!_blnExoticSkill)
 						{
-							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == MetaBase || objImprovement.ImprovedName == _strName ))
+							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == _strName || (_isMeta && objImprovement.ImprovedName == MetaBase)))
 							{
 								if (objImprovement.UniqueName != "")
 								{
@@ -2832,7 +2832,7 @@ namespace Chummer
 						// Improvement for an individual Skill.
 						if (!_blnExoticSkill)
 						{
-							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == MetaBase || objImprovement.ImprovedName == _strName))
+							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == _strName || (_isMeta && objImprovement.ImprovedName == MetaBase)))
 							{
 								if (objImprovement.UniqueName != "")
 								{
@@ -3059,7 +3059,7 @@ namespace Chummer
 						// Improvement for an individual Skill.
 						if (!_blnExoticSkill)
 						{
-							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == MetaBase || objImprovement.ImprovedName == _strName))
+							if (objImprovement.ImproveType == Improvement.ImprovementType.Skill && (objImprovement.ImprovedName == _strName || (_isMeta && objImprovement.ImprovedName == MetaBase)))
 							{
 								if (objImprovement.UniqueName != "")
 								{

--- a/Chummer/code/frmCareer.Designer.cs
+++ b/Chummer/code/frmCareer.Designer.cs
@@ -10631,7 +10631,7 @@
             this.mnuSpecialReapplyImprovements.Name = "mnuSpecialReapplyImprovements";
             this.mnuSpecialReapplyImprovements.Size = new System.Drawing.Size(246, 22);
             this.mnuSpecialReapplyImprovements.Tag = "Menu_SpecialReapplyImprovements";
-            this.mnuSpecialReapplyImprovements.Text = "Re-apply Improvements";
+            this.mnuSpecialReapplyImprovements.Text = "Reload All Data from XML Files";
             this.mnuSpecialReapplyImprovements.Click += new System.EventHandler(this.mnuSpecialReapplyImprovements_Click);
             // 
             // mnuSpecialCloningMachine

--- a/Chummer/code/frmCareer.cs
+++ b/Chummer/code/frmCareer.cs
@@ -29,6 +29,7 @@ namespace Chummer
 		private bool _blnIsDirty = false;
 		private bool _blnSkipToolStripRevert = false;
 		private bool _blnReapplyImprovements = false;
+		private bool _blnAutomaticDataUpdate = false;
 		private int _intDragLevel = 0;
 		private MouseButtons _objDragButton = new MouseButtons();
 		private bool _blnDraggingGear = false;
@@ -1311,6 +1312,12 @@ namespace Chummer
 			RefreshImprovements();
 
 			UpdateCharacterInfo();
+			if (_objCharacter.NeedsDataUpdate)
+			{
+				_blnAutomaticDataUpdate = true;
+				mnuSpecialReapplyImprovements_Click(this, EventArgs.Empty);
+				_blnAutomaticDataUpdate = false;
+			}
 
 			_blnIsDirty = false;
 			UpdateWindowTitle(false);
@@ -2187,7 +2194,7 @@ namespace Chummer
 		{
 			// This only re-applies the Improvements for everything the character has. If a match is not found in the data files, the current Improvement information is left as-is.
 			// Verify that the user wants to go through with it.
-			if (MessageBox.Show(LanguageManager.Instance.GetString("Message_ConfirmReapplyImprovements"), LanguageManager.Instance.GetString("MessageTitle_ConfirmReapplyImprovements"), MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
+			if (!_blnAutomaticDataUpdate && MessageBox.Show(LanguageManager.Instance.GetString("Message_ConfirmReapplyImprovements"), LanguageManager.Instance.GetString("MessageTitle_ConfirmReapplyImprovements"), MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
 				return;
 
 			// Record the status of any flags that normally trigger character events.
@@ -2704,6 +2711,7 @@ namespace Chummer
 				}
 			}
 
+			_objCharacter.MarkDataVersionCurrent();
 			_blnReapplyImprovements = false;
 
 			// If the status of any Character Event flags has changed, manually trigger those events.

--- a/Chummer/code/frmCreate.Designer.cs
+++ b/Chummer/code/frmCreate.Designer.cs
@@ -2373,7 +2373,7 @@
 			this.mnuSpecialReapplyImprovements.Name = "mnuSpecialReapplyImprovements";
 			this.mnuSpecialReapplyImprovements.Size = new System.Drawing.Size(208, 22);
 			this.mnuSpecialReapplyImprovements.Tag = "Menu_SpecialReapplyImprovements";
-			this.mnuSpecialReapplyImprovements.Text = "Re-apply Improvements";
+			this.mnuSpecialReapplyImprovements.Text = "Reload All Data from XML Files";
 			this.mnuSpecialReapplyImprovements.Click += new System.EventHandler(this.mnuSpecialReapplyImprovements_Click);
 			// 
 			// mnuSpecialBPAvailLimit

--- a/Chummer/code/frmCreate.cs
+++ b/Chummer/code/frmCreate.cs
@@ -24,6 +24,7 @@ namespace Chummer
 		private bool _blnIsDirty = false;
 		private bool _blnSkipToolStripRevert = false;
 		private bool _blnReapplyImprovements = false;
+		private bool _blnAutomaticDataUpdate = false;
 		private bool _blnFreestyle = false;
 		private int _intDragLevel = 0;
 		private MouseButtons _objDragButton = new MouseButtons();
@@ -1230,6 +1231,12 @@ namespace Chummer
 			UpdateInitiationGradeList();
 
 			UpdateCharacterInfo();
+			if (_objCharacter.NeedsDataUpdate)
+			{
+				_blnAutomaticDataUpdate = true;
+				mnuSpecialReapplyImprovements_Click(this, EventArgs.Empty);
+				_blnAutomaticDataUpdate = false;
+			}
 
 			_blnIsDirty = false;
 			UpdateWindowTitle(false);
@@ -2187,7 +2194,7 @@ namespace Chummer
 		{
 			// This only re-applies the Improvements for everything the character has. If a match is not found in the data files, the current Improvement information is left as-is.
 			// Verify that the user wants to go through with it.
-			if (MessageBox.Show(LanguageManager.Instance.GetString("Message_ConfirmReapplyImprovements"), LanguageManager.Instance.GetString("MessageTitle_ConfirmReapplyImprovements"), MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
+			if (!_blnAutomaticDataUpdate && MessageBox.Show(LanguageManager.Instance.GetString("Message_ConfirmReapplyImprovements"), LanguageManager.Instance.GetString("MessageTitle_ConfirmReapplyImprovements"), MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.No)
 				return;
 			
 			// Record the status of any flags that normally trigger character events.
@@ -2704,6 +2711,7 @@ namespace Chummer
 				}
 			}
 
+			_objCharacter.MarkDataVersionCurrent();
 			_blnReapplyImprovements = false;
 
 			// If the status of any Character Event flags has changed, manually trigger those events.

--- a/Chummer/data/data/armor.xml
+++ b/Chummer/data/data/armor.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-881</version>
+	<version>-880</version>
 	<categories>
 		<category>Armor</category>
 		<category>Clothing</category>

--- a/Chummer/data/data/bioware.xml
+++ b/Chummer/data/data/bioware.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-905</version>
+	<version>-904</version>
 	<grades>
 		<grade>
 			<name>Standard</name>

--- a/Chummer/data/data/cyberware.xml
+++ b/Chummer/data/data/cyberware.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-890</version>
+	<version>-889</version>
 	<grades>
 		<grade>
 			<name>Standard</name>

--- a/Chummer/data/data/gear.xml
+++ b/Chummer/data/data/gear.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-817</version>
+	<version>-816</version>
 	<categories>
 		<category show="false">Altskin Function</category>
 		<category>Ammunition</category>

--- a/Chummer/data/data/skills.xml
+++ b/Chummer/data/data/skills.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-913</version>
+	<version>-912</version>
 	<skillgroups>
 		<name>Animal Husbandry</name>
 		<name>Athletics</name>

--- a/Chummer/data/data/spells.xml
+++ b/Chummer/data/data/spells.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-917</version>
+	<version>-916</version>
 	<categories>
 		<category>Combat</category>
 		<category>Detection</category>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-945</version>
+	<version>-944</version>
 	<name>Deutsch (DE)</name>
 	<strings>
 		<string>
@@ -5776,15 +5776,15 @@
 		</string>
 		<string>
 			<key>Menu_SpecialReapplyImprovements</key>
-			<text>Verbesserung nochmal anwenden</text>
+			<text>Alle Daten aus XML-Dateien neu laden</text>
 		</string>
 		<string>
 			<key>Message_ConfirmReapplyImprovements</key>
-			<text>Chummer wird versuchen alle verbesserbaren Gegenstände zu finden um die erlaubten Verbesserungen wieder anzuwenden.Dieses bedeutet, dass sich Attribute, Fertigkeiten oder andere Werte verändern können, wenn die Gegenstände so etwas mit bringen. Es wird empfohlen den Charakter vorher zu speichern, bevor sie diese Operation durchführen. Wollen Sie wirklich die Verbesserungen erneut anwenden?</text>
+			<text>Chummer lädt alle unterstützten Charakterdaten und Verbesserungen aus den aktuellen XML-Dateien des Programms neu. Attribute, Fertigkeiten, Ausrüstungsboni und andere Werte können sich ändern, wenn die XML-Daten geändert wurden. Speichere den Charakter vorher, wenn du den aktuellen Stand behalten möchtest. Sollen wirklich alle Daten aus den XML-Dateien neu geladen werden?</text>
 		</string>
 		<string>
 			<key>MessageTitle_ConfirmReapplyImprovements</key>
-			<text>Verbesserung nochmal anwenden</text>
+			<text>Alle Daten aus XML-Dateien neu laden</text>
 		</string>
 		<string>
 			<key>Title_SelectSpellCategory</key>

--- a/Chummer/data/lang/de_data.xml
+++ b/Chummer/data/lang/de_data.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-977</version>
+	<version>-976</version>
 	<chummer file="armor.xml">
 		<categories>
 			<category translate="Panzerung">Armor</category>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-905</version>
+	<version>-904</version>
 	<name>English (US)</name>
 	<strings>
 		<!-- Common Strings -->
@@ -707,7 +707,7 @@
 		</string>
 		<string>
 			<key>Menu_SpecialReapplyImprovements</key>
-			<text>Re-apply Improvements</text>
+			<text>Reload All Data from XML Files</text>
 		</string>
 		<string>
 			<key>Menu_SpecialPossessLiving</key>
@@ -1871,11 +1871,11 @@
 		</string>
 		<string>
 			<key>Message_ConfirmReapplyImprovements</key>
-			<text>Chummer will attempt to re-locate your characters Improvable items and re-apply any Improvements they grant. This may result in your character's Attributes, Skills, and other numbers changing if any of the Improvements these items grant have changed. It is recommended that you save your character before performing this action in case you are not satisfied with the changes. Are you sure you want to re-apply Improvements?</text>
+			<text>Chummer will reload all supported character data and Improvements from the program's current XML files. Attributes, Skills, equipment bonuses, and other values may change when the XML data has changed. Save the character first if you want to preserve its current state. Do you want to reload all data from the XML files?</text>
 		</string>
 		<string>
 			<key>MessageTitle_ConfirmReapplyImprovements</key>
-			<text>Re-apply Improvements</text>
+			<text>Reload All Data from XML Files</text>
 		</string>
 		<string>
 			<key>MessageTitle_Possession</key>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-950</version>
+	<version>-949</version>
 	<name>Français</name>
 	<strings>
 		<!-- Common Strings -->
@@ -699,7 +699,7 @@
 		</string>
 		<string>
 			<key>Menu_SpecialReapplyImprovements</key>
-			<text>Ré-appliquer les améliorations</text>
+			<text>Recharger toutes les données depuis les fichiers XML</text>
 		</string>
 		<string>
 			<key>Menu_SpecialPossessLiving</key>
@@ -1867,11 +1867,11 @@
 		</string>
 		<string>
 			<key>Message_ConfirmReapplyImprovements</key>
-			<text>Chummer va tenter de rechercher toutes les possessions de votre personnage et ré-apliquer toutes les améliorations qu'elles fournissent. Cette action peut résulter en une modification des attributs et compétences de votre personnage, ainsi qu'une modification d'autre nombres en fonction des améliorations fournies. Il est donc fortement recommandé de faire une sauvegarde de votre personnage avant d'effectuer cette action au cas où vous seriez insatisfait des changements apportés. Etes-vous sûr de vouloir ré-appliquer les améliorations ?</text>
+			<text>Chummer va recharger toutes les données de personnage prises en charge et les améliorations depuis les fichiers XML actuels du programme. Les attributs, compétences, bonus d'équipement et autres valeurs peuvent changer si les données XML ont été modifiées. Enregistrez d'abord le personnage si vous souhaitez conserver son état actuel. Voulez-vous recharger toutes les données depuis les fichiers XML ?</text>
 		</string>
 		<string>
 			<key>MessageTitle_ConfirmReapplyImprovements</key>
-			<text>Ré-appliquer les améliorations</text>
+			<text>Recharger toutes les données depuis les fichiers XML</text>
 		</string>
 		<string>
 			<key>MessageTitle_Possession</key>

--- a/Chummer/data/lang/fr_data.xml
+++ b/Chummer/data/lang/fr_data.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-977</version>
+	<version>-976</version>
 	<chummer file="armor.xml">
 		<categories>
 			<category translate="Armures">Armor</category>
@@ -15685,6 +15685,31 @@
 					<spec translate="Tactile">Touch</spec>
 					<spec translate="Visuelle">Visual</spec>
 				</specs>
+				<page>124</page>
+			</skill>
+			<skill>
+				<name>Perception (Audio)</name>
+				<translate>Perception (Auditive)</translate>
+				<page>124</page>
+			</skill>
+			<skill>
+				<name>Perception (Smell)</name>
+				<translate>Perception (Olfactive)</translate>
+				<page>124</page>
+			</skill>
+			<skill>
+				<name>Perception (Taste)</name>
+				<translate>Perception (Gustative)</translate>
+				<page>124</page>
+			</skill>
+			<skill>
+				<name>Perception (Touch)</name>
+				<translate>Perception (Tactile)</translate>
+				<page>124</page>
+			</skill>
+			<skill>
+				<name>Perception (Visual)</name>
+				<translate>Perception (Visuelle)</translate>
 				<page>124</page>
 			</skill>
 			<skill>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -2,7 +2,7 @@
 <!-- この言語ファイルは AhonokoP が作成しました。連絡を取りたいときは"Dumpshock Forum"でAhonokoPにメッセージを送ってください -->
 <!-- Translated by AhonokoP. Contact me at "Dumpshock Forum" -->
 <chummer>
-	<version>-996</version>
+	<version>-995</version>
 	<name>日本語 (JP)</name>
 	<strings>
 		<!-- Common Strings -->
@@ -709,7 +709,7 @@
 		</string>
 		<string>
 			<key>Menu_SpecialReapplyImprovements</key>
-			<text>Improvements の再適用</text>
+			<text>XMLファイルからすべてのデータを再読み込み</text>
 		</string>
 		<string>
 			<key>Menu_SpecialPossessLiving</key>
@@ -1873,11 +1873,11 @@
 		</string>
 		<string>
 			<key>Message_ConfirmReapplyImprovements</key>
-			<text>Chummer はこのキャラクターの Improve 項目を再確認し, 適用する Improvement を再適用します. その結果, 適用する Improvement の値が変わっていた場合, このキャラクターの能力値, 技能, その他の数値は変更されます. 変更に不満が生じる場合に備え, 実行前にキャラクターを保存しておくことをお勧めします. Improvoment を再適用してもよろしいですか?</text>
+			<text>Chummerは、プログラムの現在のXMLファイルから、対応するすべてのキャラクターデータとImprovementを再読み込みします。XMLデータが変更されている場合、能力値、技能、装備ボーナス、その他の値が変わる可能性があります。現在の状態を保持する場合は、先にキャラクターを保存してください。XMLファイルからすべてのデータを再読み込みしますか？</text>
 		</string>
 		<string>
 			<key>MessageTitle_ConfirmReapplyImprovements</key>
-			<text>Improvements の再適用</text>
+			<text>XMLファイルからすべてのデータを再読み込み</text>
 		</string>
 		<string>
 			<key>MessageTitle_Possession</key>

--- a/Chummer/data/lang/jp_data.xml
+++ b/Chummer/data/lang/jp_data.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <!-- translated by AhonokoP. If you want to sent me a message, contact me at "Dumpshock Forum" -->
 <chummer>
-	<version>-996</version>
+	<version>-995</version>
 	<chummer file="armor.xml">
 		<categories>
 			<category translate="防具">Armor</category>
@@ -10996,6 +10996,31 @@
 					<spec translate="触覚">Touch</spec>
 					<spec translate="視覚">Visual</spec>
 				</specs>
+				<page>147</page>
+			</skill>
+			<skill>
+				<name>Perception (Audio)</name>
+				<translate>知覚 (聴覚)</translate>
+				<page>147</page>
+			</skill>
+			<skill>
+				<name>Perception (Smell)</name>
+				<translate>知覚 (嗅覚)</translate>
+				<page>147</page>
+			</skill>
+			<skill>
+				<name>Perception (Taste)</name>
+				<translate>知覚 (味覚)</translate>
+				<page>147</page>
+			</skill>
+			<skill>
+				<name>Perception (Touch)</name>
+				<translate>知覚 (触覚)</translate>
+				<page>147</page>
+			</skill>
+			<skill>
+				<name>Perception (Visual)</name>
+				<translate>知覚 (視覚)</translate>
 				<page>147</page>
 			</skill>
 			<skill>


### PR DESCRIPTION
Adds a version marker to .chum files and automatically performs a full XML-backed improvement refresh when loading an older character-data version. This fixes legacy concealability records and ensures existing cyberware, bioware, gear, spells, and nested equipment receive current Perception bonuses without repeated migrations. It also prevents ordinary skills from matching an empty meta-skill base, renames the manual action to describe the full XML reload, adds German, French, and Japanese localization coverage, and increments all affected XML file versions. Older Chummer versions ignore the optional data-version element. Validation: all changed XML files parsed successfully, git diff --check passed, and the project Compile target completed with no errors.