### PR TITLE
Automate language version updates for PRs and releases

### DIFF
--- a/.github/scripts/Update-LanguageVersions.ps1
+++ b/.github/scripts/Update-LanguageVersions.ps1
@@ -1,0 +1,134 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string] $BaseRef,
+
+    [ValidateSet("Update", "Check")]
+    [string] $Mode = "Update"
+)
+
+$ErrorActionPreference = "Stop"
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot "../..")).Path
+$languageRoot = Join-Path $repositoryRoot "Chummer/data/lang"
+$manifestPath = Join-Path $repositoryRoot "Chummer/data/manifestlang.xml"
+$versionPattern = '<version>-(\d+)</version>'
+
+function Get-VersionNumber([string] $Content, [string] $Path) {
+    $match = [regex]::Match($Content, $versionPattern)
+    if (-not $match.Success) {
+        throw "No language version found in $Path"
+    }
+    return [int] $match.Groups[1].Value
+}
+
+function Read-TextFile([string] $Path) {
+    $reader = [System.IO.StreamReader]::new($Path, $true)
+    try {
+        $content = $reader.ReadToEnd()
+        return @($content, $reader.CurrentEncoding)
+    }
+    finally {
+        $reader.Dispose()
+    }
+}
+
+function Write-TextFile([string] $Path, [string] $Content, [System.Text.Encoding] $Encoding) {
+    [System.IO.File]::WriteAllText($Path, $Content, $Encoding)
+}
+
+Push-Location $repositoryRoot
+try {
+    git rev-parse --verify $BaseRef 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "Base ref '$BaseRef' does not exist."
+    }
+
+    $changedFiles = @(git diff --name-only --diff-filter=ACMR "$BaseRef...HEAD" -- "Chummer/data/lang/*.xml")
+    $changedFiles = @($changedFiles | Where-Object { $_ -and (Test-Path $_) })
+    $errors = [System.Collections.Generic.List[string]]::new()
+
+    foreach ($relativePath in $changedFiles) {
+        $fileData = Read-TextFile (Join-Path $repositoryRoot $relativePath)
+        $content = $fileData[0]
+        if (-not [regex]::IsMatch($content, $versionPattern)) {
+            continue
+        }
+
+        $currentVersion = Get-VersionNumber $content $relativePath
+        $baseContent = git show "${BaseRef}:$relativePath" 2>$null | Out-String
+        $baseVersion = if ($LASTEXITCODE -eq 0 -and [regex]::IsMatch($baseContent, $versionPattern)) {
+            Get-VersionNumber $baseContent $relativePath
+        } else {
+            0
+        }
+
+        if ($currentVersion -le $baseVersion) {
+            $requiredVersion = $baseVersion + 1
+            if ($Mode -eq "Check") {
+                $errors.Add("$relativePath must increase its version from -$baseVersion to at least -$requiredVersion.")
+            } else {
+                $updatedContent = [regex]::Replace($content, $versionPattern, "<version>-$requiredVersion</version>", 1)
+                Write-TextFile (Join-Path $repositoryRoot $relativePath) $updatedContent $fileData[1]
+                Write-Host "Updated $relativePath from -$currentVersion to -$requiredVersion"
+            }
+        } else {
+            Write-Host "Kept manually incremented $relativePath at -$currentVersion"
+        }
+    }
+
+    [xml] $manifest = Get-Content -Raw $manifestPath
+    foreach ($file in Get-ChildItem $languageRoot -Filter "*.xml" | Sort-Object Name) {
+        $fileData = Read-TextFile $file.FullName
+        if (-not [regex]::IsMatch($fileData[0], $versionPattern)) {
+            continue
+        }
+
+        $version = Get-VersionNumber $fileData[0] $file.FullName
+        $manifestName = "lang/$($file.Name)"
+        $entry = $manifest.SelectSingleNode("/manifest/file[name='$manifestName']")
+        if ($null -eq $entry) {
+            if ($Mode -eq "Check") {
+                $errors.Add("$manifestName is missing from Chummer/data/manifestlang.xml.")
+                continue
+            }
+            $entry = $manifest.CreateElement("file")
+            foreach ($elementData in @(
+                @("name", $manifestName),
+                @("type", "Language File"),
+                @("version", "-$version"),
+                @("description", "$($file.BaseName) language file"),
+                @("notes", "$($file.BaseName) language file")
+            )) {
+                $element = $manifest.CreateElement($elementData[0])
+                $element.InnerText = $elementData[1]
+                $entry.AppendChild($element) | Out-Null
+            }
+            $manifest.DocumentElement.AppendChild($entry) | Out-Null
+            Write-Host "Added $manifestName to the language manifest"
+        } elseif ($entry.SelectSingleNode("version").InnerText -ne "-$version") {
+            if ($Mode -eq "Check") {
+                $errors.Add("$manifestName has version $($entry.SelectSingleNode("version").InnerText) in the manifest, expected -$version.")
+            } else {
+                $entry.SelectSingleNode("version").InnerText = "-$version"
+                Write-Host "Synchronized $manifestName in the language manifest"
+            }
+        }
+    }
+
+    if ($Mode -eq "Update") {
+        $settings = [System.Xml.XmlWriterSettings]::new()
+        $settings.Indent = $true
+        $settings.IndentChars = "`t"
+        $settings.NewLineChars = "`n"
+        $settings.Encoding = [System.Text.UTF8Encoding]::new($false)
+        $writer = [System.Xml.XmlWriter]::Create($manifestPath, $settings)
+        try { $manifest.Save($writer) } finally { $writer.Dispose() }
+    }
+
+    if ($errors.Count -gt 0) {
+        $errors | ForEach-Object { Write-Error $_ }
+        exit 1
+    }
+}
+finally {
+    Pop-Location
+}

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -74,7 +74,7 @@ jobs:
           path: "bin/*"
 
       - name: Upload build artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "ChummerGenSR4-${{ steps.version.outputs.version }}"
           path: "ChummerGenSR4-${{ steps.version.outputs.version }}.zip"
@@ -106,7 +106,7 @@ jobs:
           tag-prefix: v
 
       - name: Download release version
-        uses: actions/download-artifact@v2.0.10
+        uses: actions/download-artifact@v4
         with:
           name: "ChummerGenSR4-${{ steps.version.outputs.version }}"
 

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -2,9 +2,9 @@ name: Automated build
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   release:
     type: [ released ]
 
@@ -52,6 +52,16 @@ jobs:
           file: |
             "**/AssemblyInfo.cs"
           version: ${{ steps.version.outputs.version }}
+
+      - name: Update language versions for release artifacts
+        if: github.event_name == 'release'
+        shell: pwsh
+        run: |
+          $baseRef = git describe --tags --abbrev=0 HEAD^ 2>$null
+          if (-not $baseRef) {
+            $baseRef = git rev-list --max-parents=0 HEAD
+          }
+          .github/scripts/Update-LanguageVersions.ps1 -BaseRef $baseRef -Mode Update
 
       - name: Build the solution
         run: msbuild ChummerGenSR4.sln /p:Configuration=Release

--- a/.github/workflows/language-versions.yml
+++ b/.github/workflows/language-versions.yml
@@ -1,0 +1,69 @@
+name: Language versions
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - "Chummer/data/lang/*.xml"
+      - "Chummer/data/manifestlang.xml"
+      - ".github/scripts/Update-LanguageVersions.ps1"
+  push:
+    branches: [ main ]
+    paths:
+      - "Chummer/data/lang/*.xml"
+      - "Chummer/data/manifestlang.xml"
+      - ".github/scripts/Update-LanguageVersions.ps1"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update:
+    runs-on: windows-latest
+    steps:
+      - name: Check out pull request branch
+        if: github.event_name == 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+          fetch-depth: 0
+
+      - name: Check out branch
+        if: github.event_name != 'pull_request'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch pull request base
+        if: github.event_name == 'pull_request'
+        shell: pwsh
+        run: git fetch https://github.com/${{ github.repository }} ${{ github.event.pull_request.base.sha }}
+
+      - name: Update internal pull request
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
+        shell: pwsh
+        run: .github/scripts/Update-LanguageVersions.ps1 -BaseRef ${{ github.event.pull_request.base.sha }} -Mode Update
+
+      - name: Check fork pull request
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        shell: pwsh
+        run: .github/scripts/Update-LanguageVersions.ps1 -BaseRef ${{ github.event.pull_request.base.sha }} -Mode Check
+
+      - name: Update direct push
+        if: github.event_name != 'pull_request'
+        shell: pwsh
+        run: .github/scripts/Update-LanguageVersions.ps1 -BaseRef HEAD^ -Mode Update
+
+      - name: Commit automatic updates
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        shell: pwsh
+        run: |
+          if (git status --porcelain) {
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add Chummer/data/lang Chummer/data/manifestlang.xml
+            git commit -m "Update language versions [skip ci]"
+            git push
+          }

--- a/Chummer/data/manifestlang.xml
+++ b/Chummer/data/manifestlang.xml
@@ -1,31 +1,52 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <manifest>
 	<file>
 		<name>lang/en-us.xml</name>
 		<type>Language File</type>
-		<version>-964</version>
+		<version>-905</version>
 		<description>English (US) language file</description>
 		<notes>- English (US) language file</notes>
 	</file>
 	<file>
 		<name>lang/fr.xml</name>
 		<type>Language File</type>
-		<version>-963</version>
+		<version>-950</version>
 		<description>French language file</description>
 		<notes>- French language file</notes>
 	</file>
 	<file>
 		<name>lang/fr_data.xml</name>
 		<type>Language File</type>
-		<version>-986</version>
+		<version>-977</version>
 		<description>French language data file</description>
 		<notes>- French language data file</notes>
 	</file>
 	<file>
 		<name>lang/de.xml</name>
 		<type>Language File</type>
-		<version>-999</version>
+		<version>-945</version>
 		<description>German language file</description>
 		<notes>German language file</notes>
+	</file>
+	<file>
+		<name>lang/de_data.xml</name>
+		<type>Language File</type>
+		<version>-977</version>
+		<description>de_data language file</description>
+		<notes>de_data language file</notes>
+	</file>
+	<file>
+		<name>lang/jp_data.xml</name>
+		<type>Language File</type>
+		<version>-996</version>
+		<description>jp_data language file</description>
+		<notes>jp_data language file</notes>
+	</file>
+	<file>
+		<name>lang/jp.xml</name>
+		<type>Language File</type>
+		<version>-996</version>
+		<description>jp language file</description>
+		<notes>jp language file</notes>
 	</file>
 </manifest>


### PR DESCRIPTION
## Summary

- add an idempotent PowerShell tool that increments changed language-file versions only when they were not already incremented manually
- synchronize `Chummer/data/manifestlang.xml` with every versioned language XML and add missing entries
- automatically update and commit versions for internal pull requests and direct pushes to `main`
- validate fork pull requests without attempting to write to contributor branches
- run the same update before release builds as a safety net
- update the existing build workflow from `master` to `main`

## Why

Language XML changes currently rely on manual version bumps, and `manifestlang.xml` can drift out of sync. This caused repeated review feedback and stale update metadata. The new process preserves intentional manual increments while filling only missing increments.

## Validation

- exercised the update mode followed by the idempotent check mode
- parsed the synchronized manifest as XML
- ran `git diff --check`
- compiled `Chummer/Chummer.csproj` in Release configuration

Fixes #22