### PR TITLE
Add missing de/fr/jp translations for Improved Sense

### DIFF
--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -4349,6 +4349,10 @@
 			<text>Vergünstigungen für Cyberware-Essenzkosten erlauben</text>
 		</string>
 		<string>
+			<key>Checkbox_Options_ImprovedSenseFullRating</key>
+			<text>Verbesserter Sinn gewährt die volle Stufe der gewählten Cyberware</text>
+		</string>
+		<string>
 			<key>Checkbox_Options_StrengthAffectsRecoil</key>
 			<text>Stärke reduziert den Rückstoß einer Waffe (AR 171)</text>
 		</string>
@@ -5101,6 +5105,10 @@
 		<string>
 			<key>String_Improvement_SelectText</key>
 			<text>Geben Sie einen Wert für {0} ein.</text>
+		</string>
+		<string>
+			<key>String_Improvement_SelectSenseCyberware</key>
+			<text>Wählen Sie eine Sinnesverbesserung für {0}.</text>
 		</string>
 		<string>
 			<key>Message_CharacterOptions_CannotLoadSetting</key>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -5277,6 +5277,10 @@ Un saul attribut peut atteindre sa valeur maximum durant la création de personn
 			<text>Réductions des coûts d'Essence du cyberware.</text>
 		</string>
 		<string>
+			<key>Checkbox_Options_ImprovedSenseFullRating</key>
+			<text>Sens Amélioré confère le niveau complet du cyberware sélectionné</text>
+		</string>
+		<string>
 			<key>Checkbox_Options_StrengthAffectsRecoil</key>
 			<text>Une FOR extraordinaire affecte les points de CR (Ars, 162)</text>
 		</string>
@@ -6539,6 +6543,10 @@ Un saul attribut peut atteindre sa valeur maximum durant la création de personn
 		<string>
 			<key>String_Improvement_SelectText</key>
 			<text>Entrer une valeur pour {0}.</text>
+		</string>
+		<string>
+			<key>String_Improvement_SelectSenseCyberware</key>
+			<text>Sélectionnez une amélioration sensorielle pour {0}.</text>
 		</string>
 		<!-- CharacterOptions Messages -->
 		<string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -5298,6 +5298,10 @@
 			<text>サイバーウェアのエッセンスコストの軽減を認める</text>
 		</string>
 		<string>
+			<key>Checkbox_Options_ImprovedSenseFullRating</key>
+			<text>「感覚拡張」で選択したサイバーウェアのレーティングを全て適用する</text>
+		</string>
+		<string>
 			<key>Checkbox_Options_StrengthAffectsRecoil</key>
 			<text>高い【筋力】は武器の反動を軽減する (AR)</text>
 		</string>
@@ -6588,6 +6592,10 @@
 		<string>
 			<key>String_Improvement_SelectText</key>
 			<text>{0} の値を入力</text>
+		</string>
+		<string>
+			<key>String_Improvement_SelectSenseCyberware</key>
+			<text>{0} の感覚強化を選択してください。</text>
 		</string>
 		<!-- CharacterOptions Messages -->
 		<string>


### PR DESCRIPTION
## Summary
- Trailing follow-up to #29: the `Checkbox_Options_ImprovedSenseFullRating` and `String_Improvement_SelectSenseCyberware` language keys only existed in `en-us.xml`. Adds the equivalent entries to `de.xml`, `fr.xml`, and `jp.xml`.

## Test plan
- [x] All three language files verified well-formed (`xml.etree.ElementTree.parse`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)