### PR TITLE
Fix release asset upload failing on '+' in version string

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -60,7 +60,11 @@ jobs:
             [void] [int]::TryParse($candidateRevision, [ref] $revision)
           }
           $assemblyVersion = "$($coreParts[0]).$($coreParts[1]).$($coreParts[2]).$revision"
-          "version=$semanticVersion" >> $env:GITHUB_OUTPUT
+          # '+' is semver's build-metadata separator, but GitHub rejects it in release asset
+          # filenames (upload-to-release fails with HTTP 422). Use a dot there instead, matching
+          # the naming convention of previous releases (e.g. ChummerGenSR4-0.1.500.6b1453.zip).
+          $fileSafeVersion = $semanticVersion -replace '\+', '.'
+          "version=$fileSafeVersion" >> $env:GITHUB_OUTPUT
           "assembly-version=$assemblyVersion" >> $env:GITHUB_OUTPUT
 
       - name: Set project versions


### PR DESCRIPTION
## Summary
- v0.1.501's release run built fine but the upload-to-release step failed (HTTP 422) uploading `ChummerGenSR4-0.1.501+4b593a.zip` - GitHub rejects `+` in release asset filenames.
- Replaces `+` with `.` for the filename used by the zip/upload steps, matching the naming convention of previous releases (`ChummerGenSR4-0.1.500.6b1453.zip`). Assembly version is unaffected.

## Test plan
- [ ] CI: confirm `build`/`build-mono`/`validate-xml` still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)