### PR TITLE
Add Cloud Documents: RunnersPoint-backed character storage/sync (replaces Omae)

### DIFF
--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -121,15 +121,24 @@ jobs:
         uses: NuGet/setup-nuget@v4
 
       - name: Restore NuGet packages
-        run: nuget restore ChummerGenSR4.sln
+        run: nuget restore Chummer/Chummer.csproj
 
-      - name: Build the solution under Mono
+      - name: Build the app under Mono
+        # Builds only the WinForms app project, not the whole solution - Mono's bundled msbuild/xbuild
+        # can't parse Chummer.Tests.csproj's SDK-style format (it demands the old MSBuild 2003 XML
+        # namespace), and this job's job is verifying the app itself runs under Mono, not running the
+        # test suite (which is dotnet-based and wouldn't run under xbuild anyway).
+        # Platform=AnyCPU must be explicit here: Chummer.csproj's OutputPath (..\bin\, i.e. the repo
+        # root bin/ the smoke test below expects) is conditioned on Configuration|Platform =
+        # Release|AnyCPU. The .sln normally supplies that Platform via its configuration mapping;
+        # building the project directly bypasses that, so Platform defaults to something else and the
+        # build silently lands in Chummer/bin/Release/ instead.
         run: |
           if command -v msbuild >/dev/null 2>&1; then
-            msbuild ChummerGenSR4.sln /p:Configuration=Release
+            msbuild Chummer/Chummer.csproj /p:Configuration=Release /p:Platform=AnyCPU
           else
             echo "msbuild not found on PATH, falling back to xbuild"
-            xbuild ChummerGenSR4.sln /p:Configuration=Release
+            xbuild Chummer/Chummer.csproj /p:Configuration=Release /p:Platform=AnyCPU
           fi
 
       - name: Headless startup smoke test

--- a/.github/workflows/autobuild.yml
+++ b/.github/workflows/autobuild.yml
@@ -121,7 +121,11 @@ jobs:
         uses: NuGet/setup-nuget@v4
 
       - name: Restore NuGet packages
-        run: nuget restore Chummer/Chummer.csproj
+        # Points at the .sln, not Chummer.csproj directly: nuget.exe needs a solution (or an explicit
+        # -SolutionDirectory) to know where the packages/ folder is. It gracefully skips
+        # Chummer.Tests.csproj's SDK-style PackageReferences (that's dotnet's job, not classic
+        # nuget.exe's) and still restores Chummer.csproj's packages.config correctly.
+        run: nuget restore ChummerGenSR4.sln
 
       - name: Build the app under Mono
         # Builds only the WinForms app project, not the whole solution - Mono's bundled msbuild/xbuild

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 
 ### Local Directories and Subdirectories ###
 [Oo]bj/
+[Bb]in/
 
 # Visual Studio 2015 cache/options directory
 .vs/

--- a/Chummer.Tests/Chummer.Tests.csproj
+++ b/Chummer.Tests/Chummer.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net48</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <RootNamespace>Chummer.Tests</RootNamespace>
+    <AssemblyName>Chummer.Tests</AssemblyName>
+    <LangVersion>latest</LangVersion>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <NoWarn>$(NoWarn);CS1591</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Chummer\Chummer.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+</Project>

--- a/Chummer.Tests/RunnersPointApiClientTests.cs
+++ b/Chummer.Tests/RunnersPointApiClientTests.cs
@@ -135,6 +135,63 @@ namespace Chummer.Tests
 		}
 
 		[Fact]
+		public void ParseDocument_FallsBackToMetadataNameWhenDisplayNameMissing()
+		{
+			// The real server's character-document metadata extractor currently populates
+			// metadata.name (from the XML's charactername/name element), not metadata.displayName as
+			// the OpenAPI spec and this client otherwise expect. Falling back keeps the document list
+			// showing the actual character name instead of a raw GUID until that's reconciled
+			// server-side.
+			Dictionary<string, object> objJson = new Dictionary<string, object>
+			{
+				{ "id", "doc-1" },
+				{ "metadata", new Dictionary<string, object> { { "name", "Kestrel" } } },
+			};
+
+			RunnersPointDocument objDocument = RunnersPointApiClient.ParseDocument(objJson);
+
+			Assert.Equal("Kestrel", objDocument.DisplayName);
+		}
+
+		[Fact]
+		public void ParseDocument_PrefersDisplayNameOverName()
+		{
+			Dictionary<string, object> objJson = new Dictionary<string, object>
+			{
+				{ "id", "doc-1" },
+				{ "metadata", new Dictionary<string, object> { { "displayName", "Kestrel" }, { "name", "Old Name" } } },
+			};
+
+			RunnersPointDocument objDocument = RunnersPointApiClient.ParseDocument(objJson);
+
+			Assert.Equal("Kestrel", objDocument.DisplayName);
+		}
+
+		[Fact]
+		public void ExtractRawETag_ReadsUnquotedHeaderValue()
+		{
+			// Regression test: the real server sends ETag as a bare token (e.g. a revision UUID)
+			// without the DQUOTEs RFC 7232 requires. HttpResponseMessage.Headers.ETag's strongly-typed
+			// EntityTagHeaderValue parser silently refuses that and returns null instead of throwing,
+			// which meant every If-Match sent back on a later pushRevision/archive call was empty and
+			// got rejected by the server. ExtractRawETag reads the header as plain text instead.
+			HttpResponseMessage objResponse = new HttpResponseMessage();
+			objResponse.Headers.TryAddWithoutValidation("ETag", "4ee72674-de9f-402d-879c-ce9023094a25");
+
+			Assert.Equal("4ee72674-de9f-402d-879c-ce9023094a25", RunnersPointApiClient.ExtractRawETag(objResponse));
+			// Confirms the scenario the fix works around actually reproduces against .NET's own parser.
+			Assert.Null(objResponse.Headers.ETag);
+		}
+
+		[Fact]
+		public void ExtractRawETag_ReturnsNullWhenHeaderMissing()
+		{
+			HttpResponseMessage objResponse = new HttpResponseMessage();
+
+			Assert.Null(RunnersPointApiClient.ExtractRawETag(objResponse));
+		}
+
+		[Fact]
 		public void ParseDocument_ToleratesMissingOptionalFields()
 		{
 			Dictionary<string, object> objJson = new Dictionary<string, object>

--- a/Chummer.Tests/RunnersPointApiClientTests.cs
+++ b/Chummer.Tests/RunnersPointApiClientTests.cs
@@ -1,0 +1,214 @@
+using System;
+using System.Collections.Generic;
+using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text;
+using Xunit;
+
+namespace Chummer.Tests
+{
+	public class RunnersPointApiClientTests
+	{
+		private static string Sha256Base64(byte[] bytContent)
+		{
+			using (SHA256 objSha256 = SHA256.Create())
+				return Convert.ToBase64String(objSha256.ComputeHash(bytContent));
+		}
+
+		private static string Sha256Hex(byte[] bytContent)
+		{
+			using (SHA256 objSha256 = SHA256.Create())
+				return BitConverter.ToString(objSha256.ComputeHash(bytContent)).Replace("-", "").ToLowerInvariant();
+		}
+
+		[Fact]
+		public void VerifyDigest_AcceptsRfc3230Base64Prefixed()
+		{
+			byte[] bytContent = Encoding.UTF8.GetBytes("hello world");
+			string strHeader = "SHA-256=" + Sha256Base64(bytContent);
+
+			Assert.True(RunnersPointApiClient.VerifyDigest(bytContent, strHeader));
+		}
+
+		[Fact]
+		public void VerifyDigest_AcceptsBareHex()
+		{
+			byte[] bytContent = Encoding.UTF8.GetBytes("hello world");
+			string strHeader = Sha256Hex(bytContent);
+
+			Assert.True(RunnersPointApiClient.VerifyDigest(bytContent, strHeader));
+		}
+
+		[Fact]
+		public void VerifyDigest_RejectsMismatchedHash()
+		{
+			byte[] bytContent = Encoding.UTF8.GetBytes("hello world");
+			byte[] bytOther = Encoding.UTF8.GetBytes("something else entirely");
+			string strHeader = "SHA-256=" + Sha256Base64(bytOther);
+
+			Assert.False(RunnersPointApiClient.VerifyDigest(bytContent, strHeader));
+		}
+
+		[Fact]
+		public void VerifyDigest_FailsOpenOnUnrecognizedFormat()
+		{
+			// Documented behavior: a Digest header present but in a format we can't parse doesn't fail
+			// the download over a format mismatch we can't interpret, but doesn't pretend to have
+			// verified it either - VerifyDigest returns true rather than false in this case.
+			byte[] bytContent = Encoding.UTF8.GetBytes("hello world");
+			string strHeader = "not a real digest header !!";
+
+			Assert.True(RunnersPointApiClient.VerifyDigest(bytContent, strHeader));
+		}
+
+		private static HttpResponseMessage ResponseWithContentDisposition(string strValue)
+		{
+			HttpResponseMessage objResponse = new HttpResponseMessage
+			{
+				Content = new ByteArrayContent(Array.Empty<byte>()),
+			};
+			if (strValue != null)
+				objResponse.Content.Headers.TryAddWithoutValidation("Content-Disposition", strValue);
+			return objResponse;
+		}
+
+		[Fact]
+		public void ParseSuggestedFileName_ExtractsQuotedFilename()
+		{
+			HttpResponseMessage objResponse = ResponseWithContentDisposition("attachment; filename=\"my-character.chum\"");
+
+			Assert.Equal("my-character.chum", RunnersPointApiClient.ParseSuggestedFileName(objResponse));
+		}
+
+		[Fact]
+		public void ParseSuggestedFileName_ExtractsUnquotedFilename()
+		{
+			HttpResponseMessage objResponse = ResponseWithContentDisposition("attachment; filename=my-character.chum");
+
+			Assert.Equal("my-character.chum", RunnersPointApiClient.ParseSuggestedFileName(objResponse));
+		}
+
+		[Fact]
+		public void ParseSuggestedFileName_ReturnsNullWhenHeaderMissing()
+		{
+			HttpResponseMessage objResponse = ResponseWithContentDisposition(null);
+
+			Assert.Null(RunnersPointApiClient.ParseSuggestedFileName(objResponse));
+		}
+
+		[Fact]
+		public void ParseSuggestedFileName_ReturnsNullWhenNoFilenameParameter()
+		{
+			HttpResponseMessage objResponse = ResponseWithContentDisposition("attachment");
+
+			Assert.Null(RunnersPointApiClient.ParseSuggestedFileName(objResponse));
+		}
+
+		[Fact]
+		public void ParseDocument_MapsAllFieldsIncludingUpdatedAt()
+		{
+			Dictionary<string, object> objJson = new Dictionary<string, object>
+			{
+				{ "id", "doc-1" },
+				{ "type", "character" },
+				{ "gameProfileId", "profile-1" },
+				{ "format", "application/xml" },
+				{ "schemaVersion", "1" },
+				{ "currentRevision", "rev-1" },
+				{ "validationState", "accepted" },
+				{ "metadata", new Dictionary<string, object> { { "displayName", "Kestrel" } } },
+				{ "updatedAt", "2026-07-17T12:00:00+00:00" },
+			};
+
+			RunnersPointDocument objDocument = RunnersPointApiClient.ParseDocument(objJson);
+
+			Assert.Equal("doc-1", objDocument.Id);
+			Assert.Equal("character", objDocument.Type);
+			Assert.Equal("profile-1", objDocument.GameProfileId);
+			Assert.Equal("application/xml", objDocument.Format);
+			Assert.Equal("rev-1", objDocument.CurrentRevision);
+			Assert.Equal("accepted", objDocument.ValidationState);
+			Assert.Equal("Kestrel", objDocument.DisplayName);
+			// Regression test: UpdatedAt used to be parsed into a discarded local variable and never
+			// actually assigned to the DTO, so it always came back as default(DateTime).
+			Assert.Equal(new DateTime(2026, 7, 17, 12, 0, 0, DateTimeKind.Utc), objDocument.UpdatedAt.ToUniversalTime());
+		}
+
+		[Fact]
+		public void ParseDocument_ToleratesMissingOptionalFields()
+		{
+			Dictionary<string, object> objJson = new Dictionary<string, object>
+			{
+				{ "id", "doc-1" },
+			};
+
+			RunnersPointDocument objDocument = RunnersPointApiClient.ParseDocument(objJson);
+
+			Assert.Equal("doc-1", objDocument.Id);
+			Assert.Equal("", objDocument.Type);
+			Assert.Null(objDocument.DisplayName);
+		}
+
+		[Fact]
+		public void ParseSharedDocument_MapsShareGrant()
+		{
+			Dictionary<string, object> objJson = new Dictionary<string, object>
+			{
+				{ "id", "doc-1" },
+				{ "type", "character" },
+				{ "validationState", "accepted" },
+				{ "share", new Dictionary<string, object>
+					{
+						{ "permission", "write" },
+						{ "status", "active" },
+						{ "expiresAt", "2026-08-17T00:00:00+00:00" },
+					}
+				},
+			};
+
+			RunnersPointSharedDocument objShared = RunnersPointApiClient.ParseSharedDocument(objJson);
+
+			Assert.Equal("doc-1", objShared.Id);
+			Assert.Equal("write", objShared.Permission);
+			Assert.Equal("active", objShared.ShareStatus);
+			Assert.True(objShared.ExpiresAt.HasValue);
+			Assert.Equal(new DateTime(2026, 8, 17, 0, 0, 0, DateTimeKind.Utc), objShared.ExpiresAt.Value.ToUniversalTime());
+		}
+
+		[Fact]
+		public void ParseSharedDocument_ToleratesNullExpiresAt()
+		{
+			Dictionary<string, object> objJson = new Dictionary<string, object>
+			{
+				{ "id", "doc-1" },
+				{ "share", new Dictionary<string, object>
+					{
+						{ "permission", "read" },
+						{ "status", "active" },
+						{ "expiresAt", null },
+					}
+				},
+			};
+
+			RunnersPointSharedDocument objShared = RunnersPointApiClient.ParseSharedDocument(objJson);
+
+			Assert.Equal("read", objShared.Permission);
+			Assert.False(objShared.ExpiresAt.HasValue);
+		}
+
+		[Fact]
+		public void ParseSharedDocument_ToleratesMissingShare()
+		{
+			Dictionary<string, object> objJson = new Dictionary<string, object>
+			{
+				{ "id", "doc-1" },
+			};
+
+			RunnersPointSharedDocument objShared = RunnersPointApiClient.ParseSharedDocument(objJson);
+
+			Assert.Equal("doc-1", objShared.Id);
+			Assert.Null(objShared.Permission);
+			Assert.False(objShared.ExpiresAt.HasValue);
+		}
+	}
+}

--- a/Chummer.Tests/RunnersPointAuthTests.cs
+++ b/Chummer.Tests/RunnersPointAuthTests.cs
@@ -72,6 +72,31 @@ namespace Chummer.Tests
 		}
 
 		[Fact]
+		public async Task ApiToken_SurvivesReloadFromDisk()
+		{
+			// Regression test: SaveTokens serializes a null RefreshToken (always the case for an
+			// apiToken login) as a JSON null, which is still a *present* key - LoadTokens' ContainsKey
+			// check alone doesn't catch that, and calling .ToString() on the null value threw a
+			// NullReferenceException. That only happened once _objCachedTokens was empty and it had to
+			// actually deserialize the file, which a single RunnersPointAuth instance's own in-memory
+			// cache masked - so this simulates a fresh process by using a second instance.
+			RunnersPointAuth objAuth = new RunnersPointAuth();
+			try
+			{
+				objAuth.SetApiToken(ValidToken);
+
+				RunnersPointAuth objReloaded = new RunnersPointAuth();
+				string strToken = await objReloaded.GetAccessTokenAsync();
+
+				Assert.Equal(ValidToken, strToken);
+			}
+			finally
+			{
+				objAuth.Logout();
+			}
+		}
+
+		[Fact]
 		public async Task SetApiToken_ReplacesAPreviousLogin()
 		{
 			RunnersPointAuth objAuth = new RunnersPointAuth();

--- a/Chummer.Tests/RunnersPointAuthTests.cs
+++ b/Chummer.Tests/RunnersPointAuthTests.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Chummer.Tests
+{
+	// These tests exercise SetApiToken/GetAccessTokenAsync/Logout, which persist to a fixed file under
+	// %AppData%\ChummerGenSR4\cloudauth.dat. Each test cleans up via Logout() in a finally block so it
+	// doesn't leave a real stored login behind on the machine running the tests.
+	public class RunnersPointAuthTests
+	{
+		private const string ValidToken = "rp_0123456789abcdef0123456789abcdef01234567";
+
+		[Fact]
+		public async Task SetApiToken_ThenGetAccessToken_ReturnsTheSameToken()
+		{
+			RunnersPointAuth objAuth = new RunnersPointAuth();
+			try
+			{
+				objAuth.SetApiToken(ValidToken);
+
+				string strToken = await objAuth.GetAccessTokenAsync();
+
+				Assert.Equal(ValidToken, strToken);
+				Assert.True(objAuth.HasStoredLogin());
+			}
+			finally
+			{
+				objAuth.Logout();
+			}
+		}
+
+		[Fact]
+		public void SetApiToken_TrimsWhitespace()
+		{
+			RunnersPointAuth objAuth = new RunnersPointAuth();
+			try
+			{
+				objAuth.SetApiToken("  " + ValidToken + "  ");
+
+				Assert.True(objAuth.HasStoredLogin());
+			}
+			finally
+			{
+				objAuth.Logout();
+			}
+		}
+
+		[Theory]
+		[InlineData("")]
+		[InlineData("not-a-token")]
+		[InlineData("rp_tooshort")]
+		public void SetApiToken_RejectsMalformedTokens(string strBadToken)
+		{
+			RunnersPointAuth objAuth = new RunnersPointAuth();
+
+			Assert.Throws<ArgumentException>(() => objAuth.SetApiToken(strBadToken));
+			Assert.False(objAuth.HasStoredLogin());
+		}
+
+		[Fact]
+		public async Task Logout_ClearsStoredLogin()
+		{
+			RunnersPointAuth objAuth = new RunnersPointAuth();
+			objAuth.SetApiToken(ValidToken);
+			Assert.True(objAuth.HasStoredLogin());
+
+			objAuth.Logout();
+
+			Assert.False(objAuth.HasStoredLogin());
+			await Assert.ThrowsAsync<InvalidOperationException>(() => objAuth.GetAccessTokenAsync());
+		}
+
+		[Fact]
+		public async Task SetApiToken_ReplacesAPreviousLogin()
+		{
+			RunnersPointAuth objAuth = new RunnersPointAuth();
+			try
+			{
+				objAuth.SetApiToken(ValidToken);
+				string strSecondToken = "rp_fedcba9876543210fedcba9876543210fedcba98";
+				objAuth.SetApiToken(strSecondToken);
+
+				string strToken = await objAuth.GetAccessTokenAsync();
+
+				Assert.Equal(strSecondToken, strToken);
+			}
+			finally
+			{
+				objAuth.Logout();
+			}
+		}
+	}
+}

--- a/Chummer.Tests/RunnersPointAuthTests.cs
+++ b/Chummer.Tests/RunnersPointAuthTests.cs
@@ -97,6 +97,37 @@ namespace Chummer.Tests
 		}
 
 		[Fact]
+		public async Task TryForceRefreshAsync_ReturnsFalseForApiTokenLogin()
+		{
+			// apiToken logins have no refresh token at all - there's nothing to refresh, so a 401 retry
+			// should fall straight through to the normal auth-expired handling instead of attempting (and
+			// failing) an OAuth-style refresh.
+			RunnersPointAuth objAuth = new RunnersPointAuth();
+			try
+			{
+				objAuth.SetApiToken(ValidToken);
+
+				bool blnRefreshed = await objAuth.TryForceRefreshAsync();
+
+				Assert.False(blnRefreshed);
+			}
+			finally
+			{
+				objAuth.Logout();
+			}
+		}
+
+		[Fact]
+		public async Task TryForceRefreshAsync_ReturnsFalseWhenNotLoggedIn()
+		{
+			RunnersPointAuth objAuth = new RunnersPointAuth();
+
+			bool blnRefreshed = await objAuth.TryForceRefreshAsync();
+
+			Assert.False(blnRefreshed);
+		}
+
+		[Fact]
 		public async Task SetApiToken_ReplacesAPreviousLogin()
 		{
 			RunnersPointAuth objAuth = new RunnersPointAuth();

--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -100,6 +100,12 @@
     <Reference Include="System.Numerics.Vectors">
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
+    <Reference Include="Serilog">
+      <HintPath>..\packages\Serilog.4.2.0\lib\net471\Serilog.dll</HintPath>
+    </Reference>
+    <Reference Include="Serilog.Sinks.File">
+      <HintPath>..\packages\Serilog.Sinks.File.6.0.0\lib\net471\Serilog.Sinks.File.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="code\clsCommon.cs" />

--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -117,6 +117,12 @@
     <Compile Include="code\frmCloudDocuments.Designer.cs">
       <DependentUpon>frmCloudDocuments.cs</DependentUpon>
     </Compile>
+    <Compile Include="code\frmCloudMetadata.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="code\frmCloudMetadata.Designer.cs">
+      <DependentUpon>frmCloudMetadata.cs</DependentUpon>
+    </Compile>
     <Compile Include="code\clsEquipment.cs" />
     <Compile Include="code\clsCharacter.cs" />
     <Compile Include="code\clsImprovement.cs" />

--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -76,6 +76,8 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.Web.Extensions" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Security" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="WindowsBase" />
@@ -101,6 +103,14 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="code\clsCommon.cs" />
+    <Compile Include="code\clsRunnersPointApiClient.cs" />
+    <Compile Include="code\clsRunnersPointAuth.cs" />
+    <Compile Include="code\frmCloudDocuments.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="code\frmCloudDocuments.Designer.cs">
+      <DependentUpon>frmCloudDocuments.cs</DependentUpon>
+    </Compile>
     <Compile Include="code\clsEquipment.cs" />
     <Compile Include="code\clsCharacter.cs" />
     <Compile Include="code\clsImprovement.cs" />

--- a/Chummer/Chummer.csproj
+++ b/Chummer/Chummer.csproj
@@ -101,10 +101,10 @@
       <HintPath>..\packages\System.Numerics.Vectors.4.5.0\lib\net46\System.Numerics.Vectors.dll</HintPath>
     </Reference>
     <Reference Include="Serilog">
-      <HintPath>..\packages\Serilog.4.2.0\lib\net471\Serilog.dll</HintPath>
+      <HintPath>..\packages\Serilog.2.12.0\lib\net47\Serilog.dll</HintPath>
     </Reference>
     <Reference Include="Serilog.Sinks.File">
-      <HintPath>..\packages\Serilog.Sinks.File.6.0.0\lib\net471\Serilog.Sinks.File.dll</HintPath>
+      <HintPath>..\packages\Serilog.Sinks.File.5.0.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>

--- a/Chummer/Properties/AssemblyInfo.cs
+++ b/Chummer/Properties/AssemblyInfo.cs
@@ -19,6 +19,10 @@ using System.Runtime.InteropServices;
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 
+// Lets Chummer.Tests call internal helpers (JSON parsing, digest verification, etc.) directly
+// instead of only through the public async API methods that need a live HTTP server.
+[assembly: InternalsVisibleTo("Chummer.Tests")]
+
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("28a46ea3-4e45-4842-b8ae-313afde61173")]
 

--- a/Chummer/code/Program.cs
+++ b/Chummer/code/Program.cs
@@ -1,7 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
+using Serilog;
 
 namespace Chummer
 {
@@ -13,14 +16,59 @@ namespace Chummer
         [STAThread]
         static void Main()
         {
-            Application.EnableVisualStyles();
-            Application.SetCompatibleTextRenderingDefault(false);
-			LanguageManager.Instance.Load(GlobalOptions.Instance.Language, null);
-			// Make sure the default language has been loaded before attempting to open the Main Form.
-			if (LanguageManager.Instance.Loaded)
-				Application.Run(new frmMain());
-			else
-				Application.Exit();
+            InitializeLogging();
+            AppDomain.CurrentDomain.UnhandledException += OnUnhandledException;
+            Application.ThreadException += OnThreadException;
+
+            try
+            {
+                Application.EnableVisualStyles();
+                Application.SetCompatibleTextRenderingDefault(false);
+				LanguageManager.Instance.Load(GlobalOptions.Instance.Language, null);
+				// Make sure the default language has been loaded before attempting to open the Main Form.
+				if (LanguageManager.Instance.Loaded)
+					Application.Run(new frmMain());
+				else
+					Application.Exit();
+            }
+            finally
+            {
+                Log.CloseAndFlush();
+            }
+        }
+
+        private static void InitializeLogging()
+        {
+            string strLogDirectory = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ChummerGenSR4", "logs");
+            if (!Directory.Exists(strLogDirectory))
+                Directory.CreateDirectory(strLogDirectory);
+
+            Log.Logger = new LoggerConfiguration()
+                .MinimumLevel.Information()
+                .Enrich.WithProperty("Version", System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString())
+                .WriteTo.File(
+                    Path.Combine(strLogDirectory, "chummer-.log"),
+                    rollingInterval: RollingInterval.Day,
+                    retainedFileCountLimit: 14,
+                    outputTemplate: "{Timestamp:yyyy-MM-dd HH:mm:ss.fff zzz} [{Level:u3}] {Message:lj}{NewLine}{Exception}")
+                .CreateLogger();
+
+            Log.Information("Chummer starting up");
+        }
+
+        private static void OnUnhandledException(object sender, UnhandledExceptionEventArgs e)
+        {
+            Log.Fatal(e.ExceptionObject as Exception, "Unhandled exception (IsTerminating={IsTerminating})", e.IsTerminating);
+            if (e.IsTerminating)
+                Log.CloseAndFlush();
+        }
+
+        private static void OnThreadException(object sender, ThreadExceptionEventArgs e)
+        {
+            // WinForms shows its own default crash dialog for this after the event handler returns -
+            // logging here doesn't change that behavior, it just makes sure the exception survives
+            // past the dialog into a file we can actually look at afterwards.
+            Log.Error(e.Exception, "Unhandled UI thread exception");
         }
     }
 }

--- a/Chummer/code/clsCharacter.cs
+++ b/Chummer/code/clsCharacter.cs
@@ -55,6 +55,13 @@ namespace Chummer
 		private string _strFileName = "";
 		private string _strSettingsFileName = "default.xml";
 		private string _strCloudDocumentId = "";
+		// Local-only for now: the RunnersPoint API has no way for a client to submit document metadata
+		// at all (create/pushRevision take only raw file bytes, no metadata field), so these aren't sent
+		// anywhere yet. Staged for when/if the server adds that - see the "Document metadata mismatch"
+		// bug report (metadata.displayName/description/imageUrl per the OpenAPI spec).
+		private string _strCloudMetadataDisplayName = "";
+		private string _strCloudMetadataDescription = "";
+		private string _strCloudMetadataImageUrl = "";
 		private bool _blnIgnoreRules = false;
 		private int _intKarma = 0;
 		private int _intTotalKarma = 0;
@@ -301,6 +308,12 @@ namespace Chummer
 			objWriter.WriteElementString("gamenotes", _strGameNotes);
 			// <clouddocumentid />
 			objWriter.WriteElementString("clouddocumentid", _strCloudDocumentId);
+			// <clouddisplayname />
+			objWriter.WriteElementString("clouddisplayname", _strCloudMetadataDisplayName);
+			// <clouddescription />
+			objWriter.WriteElementString("clouddescription", _strCloudMetadataDescription);
+			// <cloudimageurl />
+			objWriter.WriteElementString("cloudimageurl", _strCloudMetadataImageUrl);
 
 			// <ignorerules />
 			if (_blnIgnoreRules)
@@ -902,6 +915,27 @@ namespace Chummer
 			try
 			{
 				_strCloudDocumentId = objXmlCharacter["clouddocumentid"].InnerText;
+			}
+			catch
+			{
+			}
+			try
+			{
+				_strCloudMetadataDisplayName = objXmlCharacter["clouddisplayname"].InnerText;
+			}
+			catch
+			{
+			}
+			try
+			{
+				_strCloudMetadataDescription = objXmlCharacter["clouddescription"].InnerText;
+			}
+			catch
+			{
+			}
+			try
+			{
+				_strCloudMetadataImageUrl = objXmlCharacter["cloudimageurl"].InnerText;
 			}
 			catch
 			{
@@ -2746,6 +2780,56 @@ namespace Chummer
 			set
 			{
 				_strCloudDocumentId = value;
+			}
+		}
+
+		/// <summary>
+		/// Display name to use for this character's cloud document, per the RunnersPoint API's
+		/// Document.metadata.displayName field. Local-only for now - the API has no way for a client to
+		/// submit metadata yet (see the metadata mismatch bug report), so this isn't sent anywhere until
+		/// that changes.
+		/// </summary>
+		public string CloudMetadataDisplayName
+		{
+			get
+			{
+				return _strCloudMetadataDisplayName;
+			}
+			set
+			{
+				_strCloudMetadataDisplayName = value;
+			}
+		}
+
+		/// <summary>
+		/// Description for this character's cloud document, per Document.metadata.description. Local-only
+		/// for now - see CloudMetadataDisplayName.
+		/// </summary>
+		public string CloudMetadataDescription
+		{
+			get
+			{
+				return _strCloudMetadataDescription;
+			}
+			set
+			{
+				_strCloudMetadataDescription = value;
+			}
+		}
+
+		/// <summary>
+		/// Portrait/image URL for this character's cloud document, per Document.metadata.imageUrl.
+		/// Local-only for now - see CloudMetadataDisplayName.
+		/// </summary>
+		public string CloudMetadataImageUrl
+		{
+			get
+			{
+				return _strCloudMetadataImageUrl;
+			}
+			set
+			{
+				_strCloudMetadataImageUrl = value;
 			}
 		}
 

--- a/Chummer/code/clsCharacter.cs
+++ b/Chummer/code/clsCharacter.cs
@@ -54,6 +54,7 @@ namespace Chummer
 
 		private string _strFileName = "";
 		private string _strSettingsFileName = "default.xml";
+		private string _strCloudDocumentId = "";
 		private bool _blnIgnoreRules = false;
 		private int _intKarma = 0;
 		private int _intTotalKarma = 0;
@@ -298,6 +299,8 @@ namespace Chummer
 			objWriter.WriteElementString("playername", _strPlayerName);
 			// <gamenotes />
 			objWriter.WriteElementString("gamenotes", _strGameNotes);
+			// <clouddocumentid />
+			objWriter.WriteElementString("clouddocumentid", _strCloudDocumentId);
 
 			// <ignorerules />
 			if (_blnIgnoreRules)
@@ -892,6 +895,13 @@ namespace Chummer
 			try
 			{
 				_strAlias = objXmlCharacter["alias"].InnerText;
+			}
+			catch
+			{
+			}
+			try
+			{
+				_strCloudDocumentId = objXmlCharacter["clouddocumentid"].InnerText;
 			}
 			catch
 			{
@@ -2724,7 +2734,23 @@ namespace Chummer
 		}
 
 		/// <summary>
-		/// Name of the settings file the Character uses. 
+		/// Id of the RunnersPoint cloud document this character is linked to, if any. Cleared on Save As
+		/// so a copy of a character becomes its own independent cloud document on first push.
+		/// </summary>
+		public string CloudDocumentId
+		{
+			get
+			{
+				return _strCloudDocumentId;
+			}
+			set
+			{
+				_strCloudDocumentId = value;
+			}
+		}
+
+		/// <summary>
+		/// Name of the settings file the Character uses.
 		/// </summary>
 		public string SettingsFile
 		{

--- a/Chummer/code/clsOptions.cs
+++ b/Chummer/code/clsOptions.cs
@@ -89,6 +89,7 @@ namespace Chummer
 		private static string _strLanguage = "en-us";
 		private static string _strDefaultCharacterSheet = "Shadowrun 4";
 		private static string _strPDFArgumentStyle = "Adobe/Foxit";
+		private static string _strCloudApiBaseUrl = "http://localhost:8000/api/v1";
 		private static bool _blnDatesIncludeTime = true;
 		private static bool _blnPrintToFileFirst = false;
 
@@ -201,6 +202,14 @@ namespace Chummer
 			try
 			{
 				_strPDFArgumentStyle = CheckAndGetRegistryKeyWithFallback("Software\\Chummer", "pdfargumentstyle", "Adobe/Foxit");
+			}
+			catch
+			{
+			}
+
+			try
+			{
+				_strCloudApiBaseUrl = CheckAndGetRegistryKeyWithFallback("Software\\Chummer", "cloudapibaseurl", "http://localhost:8000/api/v1");
 			}
 			catch
 			{
@@ -557,6 +566,22 @@ namespace Chummer
 			set
 			{
 				_strPDFArgumentStyle = value;
+			}
+		}
+
+		/// <summary>
+		/// Base URL (including path prefix, e.g. "http://localhost:8000/api/v1") of the RunnersPoint
+		/// Character Document Storage API that Cloud Documents talks to.
+		/// </summary>
+		public string CloudApiBaseUrl
+		{
+			get
+			{
+				return _strCloudApiBaseUrl;
+			}
+			set
+			{
+				_strCloudApiBaseUrl = value;
 			}
 		}
 

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -57,10 +57,32 @@ namespace Chummer
 		public List<string> Formats { get; set; } = new List<string>();
 	}
 
+	/// <summary>
+	/// One media type a registered document type accepts (e.g. "application/xml" for "character"),
+	/// plus its own upload size ceiling.
+	/// </summary>
+	public class RunnersPointDocumentFormatCapability
+	{
+		public string MediaType { get; set; }
+		public long MaxUploadBytes { get; set; }
+	}
+
+	/// <summary>
+	/// One entry from Capabilities.documentTypes - the registered type id (e.g. "character") Chummer
+	/// sends as X-Document-Type, and the formats it accepts.
+	/// </summary>
+	public class RunnersPointDocumentTypeCapability
+	{
+		public string Id { get; set; }
+		public string DisplayName { get; set; }
+		public List<RunnersPointDocumentFormatCapability> Formats { get; set; } = new List<RunnersPointDocumentFormatCapability>();
+	}
+
 	public class RunnersPointCapabilities
 	{
 		public string ApiVersion { get; set; }
 		public List<RunnersPointGameProfile> GameProfiles { get; set; } = new List<RunnersPointGameProfile>();
+		public List<RunnersPointDocumentTypeCapability> DocumentTypes { get; set; } = new List<RunnersPointDocumentTypeCapability>();
 		public List<string> Formats { get; set; } = new List<string>();
 		public long MaxUploadBytes { get; set; }
 	}
@@ -226,6 +248,30 @@ namespace Chummer
 							objGameProfile.Formats.Add(objFormat.ToString());
 					}
 					objCapabilities.GameProfiles.Add(objGameProfile);
+				}
+			}
+
+			if (objJson.ContainsKey("documentTypes"))
+			{
+				foreach (object objTypeObj in (object[])objJson["documentTypes"])
+				{
+					Dictionary<string, object> objType = (Dictionary<string, object>)objTypeObj;
+					RunnersPointDocumentTypeCapability objTypeCapability = new RunnersPointDocumentTypeCapability();
+					objTypeCapability.Id = objType.ContainsKey("id") ? objType["id"].ToString() : "";
+					objTypeCapability.DisplayName = objType.ContainsKey("displayName") ? objType["displayName"].ToString() : "";
+					if (objType.ContainsKey("formats"))
+					{
+						foreach (object objFormatObj in (object[])objType["formats"])
+						{
+							Dictionary<string, object> objFormat = (Dictionary<string, object>)objFormatObj;
+							objTypeCapability.Formats.Add(new RunnersPointDocumentFormatCapability
+							{
+								MediaType = objFormat.ContainsKey("mediaType") ? objFormat["mediaType"].ToString() : "",
+								MaxUploadBytes = objFormat.ContainsKey("maxUploadBytes") ? Convert.ToInt64(objFormat["maxUploadBytes"]) : 0,
+							});
+						}
+					}
+					objCapabilities.DocumentTypes.Add(objTypeCapability);
 				}
 			}
 
@@ -409,7 +455,7 @@ namespace Chummer
 		/// since silently trusting an unverified download for a "store my character" feature is asking
 		/// for a corrupted/truncated file to go unnoticed.
 		/// </summary>
-		public async Task<byte[]> DownloadRevisionAsync(string strDocumentId, string strRevisionId)
+		public async Task<Tuple<byte[], string>> DownloadRevisionAsync(string strDocumentId, string strRevisionId)
 		{
 			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/documents/" + strDocumentId + "/revisions/" + strRevisionId + "/content");
 			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
@@ -424,7 +470,33 @@ namespace Chummer
 					throw new InvalidOperationException("Downloaded content for revision " + strRevisionId + " failed digest verification - the bytes received don't match the server's declared hash. Discarding rather than saving a possibly-corrupted file.");
 			}
 
-			return bytContent;
+			return new Tuple<byte[], string>(bytContent, ParseSuggestedFileName(objResponse));
+		}
+
+		/// <summary>
+		/// Extracts a suggested filename from a Content-Disposition response header, if the server sent
+		/// one - not all deployments do (it's an optional hint per the spec), so callers should fall back
+		/// to something derived from the document's own metadata when this returns null.
+		/// </summary>
+		private static string ParseSuggestedFileName(HttpResponseMessage objResponse)
+		{
+			IEnumerable<string> lstValues;
+			if (!objResponse.Headers.TryGetValues("Content-Disposition", out lstValues))
+				return null;
+
+			string strHeader = lstValues.FirstOrDefault();
+			if (string.IsNullOrEmpty(strHeader))
+				return null;
+
+			int intFilenameIndex = strHeader.IndexOf("filename=", StringComparison.OrdinalIgnoreCase);
+			if (intFilenameIndex < 0)
+				return null;
+
+			string strFileName = strHeader.Substring(intFilenameIndex + "filename=".Length).Trim();
+			int intSemicolon = strFileName.IndexOf(';');
+			if (intSemicolon >= 0)
+				strFileName = strFileName.Substring(0, intSemicolon);
+			return strFileName.Trim().Trim('"');
 		}
 
 		/// <summary>
@@ -563,7 +635,7 @@ namespace Chummer
 		/// as DownloadRevisionAsync - a shared download is downloaded from someone else's storage, so
 		/// verifying it wasn't corrupted or truncated in transit matters at least as much here.
 		/// </summary>
-		public async Task<byte[]> DownloadSharedDocumentRevisionAsync(string strDocumentId, string strRevisionId)
+		public async Task<Tuple<byte[], string>> DownloadSharedDocumentRevisionAsync(string strDocumentId, string strRevisionId)
 		{
 			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/shared/documents/" + strDocumentId + "/revisions/" + strRevisionId + "/content");
 			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
@@ -578,7 +650,7 @@ namespace Chummer
 					throw new InvalidOperationException("Downloaded content for shared revision " + strRevisionId + " failed digest verification - the bytes received don't match the server's declared hash. Discarding rather than saving a possibly-corrupted file.");
 			}
 
-			return bytContent;
+			return new Tuple<byte[], string>(bytContent, ParseSuggestedFileName(objResponse));
 		}
 	}
 }

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -62,7 +62,28 @@ namespace Chummer
 		public string ApiVersion { get; set; }
 		public List<RunnersPointGameProfile> GameProfiles { get; set; } = new List<RunnersPointGameProfile>();
 		public List<string> Formats { get; set; } = new List<string>();
-		public long MaximumUploadBytes { get; set; }
+		public long MaxUploadBytes { get; set; }
+	}
+
+	/// <summary>
+	/// A document explicitly shared with the authenticated user by another user (e.g. a GM sharing a
+	/// character, or a document originating from a marketplace on the RunnersPoint website). Chummer
+	/// never sees a public listing - only documents an active share grant actually covers.
+	/// </summary>
+	public class RunnersPointSharedDocument : RunnersPointDocument
+	{
+		public string Permission { get; set; }
+		public string ShareStatus { get; set; }
+		public DateTime? ExpiresAt { get; set; }
+	}
+
+	/// <summary>
+	/// A page of SharedDocuments from listSharedDocuments, plus the cursor needed to keep paging.
+	/// </summary>
+	public class RunnersPointSharedDocumentPage
+	{
+		public List<RunnersPointSharedDocument> Items { get; set; } = new List<RunnersPointSharedDocument>();
+		public string NextCursor { get; set; }
 	}
 
 	/// <summary>
@@ -86,10 +107,10 @@ namespace Chummer
 	}
 
 	/// <summary>
-	/// Thin wrapper over the RunnersPoint Character Document Storage API (v1, draft.2). Only implements
-	/// the operations the Chummer client actually uses - personal storage/sync of `character` documents.
-	/// Sharing/discovery and non-character document types are out of scope for this client (see
-	/// docs/api/open-questions-character-document-storage-v1.md in the RunnersPoint repo).
+	/// Thin wrapper over the RunnersPoint Character Document Storage API (v1, draft.6). Covers personal
+	/// storage/sync of `character` documents, plus read-only-or-write access to documents explicitly
+	/// shared with the authenticated user via `/shared/documents/*` (per-document grants only - there is
+	/// no public marketplace/discovery surface in this API; that lives on the RunnersPoint website).
 	/// </summary>
 	public class RunnersPointApiClient
 	{
@@ -178,7 +199,7 @@ namespace Chummer
 
 			RunnersPointCapabilities objCapabilities = new RunnersPointCapabilities();
 			objCapabilities.ApiVersion = objJson.ContainsKey("apiVersion") ? objJson["apiVersion"].ToString() : "";
-			objCapabilities.MaximumUploadBytes = objJson.ContainsKey("maximumUploadBytes") ? Convert.ToInt64(objJson["maximumUploadBytes"]) : 0;
+			objCapabilities.MaxUploadBytes = objJson.ContainsKey("maxUploadBytes") ? Convert.ToInt64(objJson["maxUploadBytes"]) : 0;
 
 			if (objJson.ContainsKey("formats"))
 			{
@@ -253,9 +274,41 @@ namespace Chummer
 				if (objMetadata.ContainsKey("displayName"))
 					objDocument.DisplayName = objMetadata["displayName"].ToString();
 			}
-			if (objJson.ContainsKey("updatedAt"))
-				DateTime.TryParse(objJson["updatedAt"].ToString(), out DateTime datUpdatedAt);
+			if (objJson.ContainsKey("updatedAt") && DateTime.TryParse(objJson["updatedAt"].ToString(), out DateTime datUpdatedAt))
+				objDocument.UpdatedAt = datUpdatedAt;
 			return objDocument;
+		}
+
+		/// <summary>
+		/// Parses a SharedDocument - the same envelope as Document, plus a required `share` grant
+		/// (permission/status/expiresAt) describing what the authenticated user is allowed to do with it.
+		/// </summary>
+		private static RunnersPointSharedDocument ParseSharedDocument(Dictionary<string, object> objJson)
+		{
+			RunnersPointDocument objBase = ParseDocument(objJson);
+			RunnersPointSharedDocument objShared = new RunnersPointSharedDocument
+			{
+				Id = objBase.Id,
+				Type = objBase.Type,
+				GameProfileId = objBase.GameProfileId,
+				Format = objBase.Format,
+				SchemaVersion = objBase.SchemaVersion,
+				CurrentRevision = objBase.CurrentRevision,
+				ValidationState = objBase.ValidationState,
+				DisplayName = objBase.DisplayName,
+				UpdatedAt = objBase.UpdatedAt
+			};
+
+			if (objJson.ContainsKey("share") && objJson["share"] is Dictionary<string, object> objShare)
+			{
+				objShared.Permission = objShare.ContainsKey("permission") ? objShare["permission"].ToString() : "";
+				objShared.ShareStatus = objShare.ContainsKey("status") ? objShare["status"].ToString() : "";
+				if (objShare.ContainsKey("expiresAt") && objShare["expiresAt"] != null
+					&& DateTime.TryParse(objShare["expiresAt"].ToString(), out DateTime datExpiresAt))
+					objShared.ExpiresAt = datExpiresAt;
+			}
+
+			return objShared;
 		}
 
 		/// <summary>
@@ -283,6 +336,7 @@ namespace Chummer
 		{
 			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Post, "/documents");
 			objRequest.Headers.Add("Idempotency-Key", NewIdempotencyKey());
+			objRequest.Headers.Add("X-Document-Type", "character");
 			objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
 			objRequest.Headers.Add("X-Document-Format", strFormat);
 			objRequest.Content = new ByteArrayContent(bytContent);
@@ -431,6 +485,97 @@ namespace Chummer
 
 			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
 			await ThrowIfProblemAsync(objResponse);
+		}
+
+		/// <summary>
+		/// GET /shared/documents. Documents explicitly shared with the authenticated user by another
+		/// user - e.g. a GM sharing a character back, or a document someone picked up from a marketplace
+		/// on the RunnersPoint website. Chummer only ever sees the individual grant; there is no public
+		/// browsing here.
+		/// </summary>
+		public async Task<RunnersPointSharedDocumentPage> ListSharedDocumentsAsync(string strGameProfileId, string strCursor = null, int intPageSize = 25)
+		{
+			string strPath = "/shared/documents?gameProfileId=" + Uri.EscapeDataString(strGameProfileId) + "&pageSize=" + intPageSize;
+			if (!string.IsNullOrEmpty(strCursor))
+				strPath += "&cursor=" + Uri.EscapeDataString(strCursor);
+
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, strPath);
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+
+			string strBody = await objResponse.Content.ReadAsStringAsync();
+			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+			Dictionary<string, object> objJson = objSerializer.Deserialize<Dictionary<string, object>>(strBody);
+
+			RunnersPointSharedDocumentPage objPage = new RunnersPointSharedDocumentPage();
+			objPage.NextCursor = objJson.ContainsKey("nextCursor") && objJson["nextCursor"] != null ? objJson["nextCursor"].ToString() : null;
+
+			if (objJson.ContainsKey("items"))
+			{
+				foreach (object objItemObj in (object[])objJson["items"])
+					objPage.Items.Add(ParseSharedDocument((Dictionary<string, object>)objItemObj));
+			}
+
+			return objPage;
+		}
+
+		/// <summary>
+		/// GET /shared/documents/{documentId}. Same ETag contract as GetDocumentAsync - needed before
+		/// calling PushSharedDocumentRevisionAsync.
+		/// </summary>
+		public async Task<Tuple<RunnersPointSharedDocument, string>> GetSharedDocumentAsync(string strDocumentId)
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/shared/documents/" + strDocumentId);
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+
+			string strBody = await objResponse.Content.ReadAsStringAsync();
+			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+			RunnersPointSharedDocument objDocument = ParseSharedDocument(objSerializer.Deserialize<Dictionary<string, object>>(strBody));
+			string strETag = objResponse.Headers.ETag != null ? objResponse.Headers.ETag.Tag : null;
+			return new Tuple<RunnersPointSharedDocument, string>(objDocument, strETag);
+		}
+
+		/// <summary>
+		/// PUT /shared/documents/{documentId}. Requires an active write grant on the document - archive
+		/// and delete are never available through shared access, only through the owner's own /documents.
+		/// </summary>
+		public async Task<RunnersPointRevisionStatus> PushSharedDocumentRevisionAsync(string strDocumentId, byte[] bytContent, string strIfMatch, string strGameProfileId, string strFormat)
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Put, "/shared/documents/" + strDocumentId);
+			objRequest.Headers.Add("Idempotency-Key", NewIdempotencyKey());
+			objRequest.Headers.Add("If-Match", strIfMatch);
+			objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
+			objRequest.Headers.Add("X-Document-Format", strFormat);
+			objRequest.Content = new ByteArrayContent(bytContent);
+			objRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+			return await ParseRevisionStatusAsync(objResponse);
+		}
+
+		/// <summary>
+		/// GET /shared/documents/{documentId}/revisions/{revisionId}/content. Same Digest verification
+		/// as DownloadRevisionAsync - a shared download is downloaded from someone else's storage, so
+		/// verifying it wasn't corrupted or truncated in transit matters at least as much here.
+		/// </summary>
+		public async Task<byte[]> DownloadSharedDocumentRevisionAsync(string strDocumentId, string strRevisionId)
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/shared/documents/" + strDocumentId + "/revisions/" + strRevisionId + "/content");
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+			byte[] bytContent = await objResponse.Content.ReadAsByteArrayAsync();
+
+			IEnumerable<string> lstDigestValues;
+			if (objResponse.Headers.TryGetValues("Digest", out lstDigestValues))
+			{
+				string strDigestHeader = lstDigestValues.FirstOrDefault();
+				if (!string.IsNullOrEmpty(strDigestHeader) && !VerifyDigest(bytContent, strDigestHeader))
+					throw new InvalidOperationException("Downloaded content for shared revision " + strRevisionId + " failed digest verification - the bytes received don't match the server's declared hash. Discarding rather than saving a possibly-corrupted file.");
+			}
+
+			return bytContent;
 		}
 	}
 }

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -173,6 +173,21 @@ namespace Chummer
 		}
 
 		/// <summary>
+		/// Reads the raw ETag header value, bypassing HttpResponseMessage.Headers.ETag's strongly-typed
+		/// EntityTagHeaderValue parsing. The server sends ETag as a bare opaque token (e.g. a revision
+		/// UUID) without the DQUOTEs RFC 7232 requires around an entity-tag; .NET's typed parser silently
+		/// refuses anything unquoted and leaves Headers.ETag null instead of throwing, which meant every
+		/// If-Match sent back (pushRevision, archive) was empty and got rejected. Reading the header as
+		/// plain text and echoing it back exactly as received round-trips correctly against this server,
+		/// even though it isn't RFC-conformant.
+		/// </summary>
+		internal static string ExtractRawETag(HttpResponseMessage objResponse)
+		{
+			IEnumerable<string> lstValues;
+			return objResponse.Headers.TryGetValues("ETag", out lstValues) ? lstValues.FirstOrDefault() : null;
+		}
+
+		/// <summary>
 		/// Sends an authenticated request built by requestFactory. If the server responds 401, forces a
 		/// token refresh and retries once with a freshly-built request (a request/its content can't be
 		/// resent as-is once sent, hence rebuilding rather than reusing the same HttpRequestMessage). If
@@ -355,6 +370,12 @@ namespace Chummer
 				Dictionary<string, object> objMetadata = (Dictionary<string, object>)objJson["metadata"];
 				if (objMetadata.ContainsKey("displayName"))
 					objDocument.DisplayName = objMetadata["displayName"].ToString();
+				// The server's character-document extractor currently populates metadata.name (the
+				// charactername/name XML element), not metadata.displayName as the spec and this client
+				// otherwise expect - fall back to it so the list doesn't just show raw document IDs for
+				// every character until that's reconciled server-side.
+				else if (objMetadata.ContainsKey("name"))
+					objDocument.DisplayName = objMetadata["name"].ToString();
 			}
 			if (objJson.ContainsKey("updatedAt") && DateTime.TryParse(objJson["updatedAt"].ToString(), out DateTime datUpdatedAt))
 				objDocument.UpdatedAt = datUpdatedAt;
@@ -405,7 +426,7 @@ namespace Chummer
 			string strBody = await objResponse.Content.ReadAsStringAsync();
 			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
 			RunnersPointDocument objDocument = ParseDocument(objSerializer.Deserialize<Dictionary<string, object>>(strBody));
-			string strETag = objResponse.Headers.ETag != null ? objResponse.Headers.ETag.Tag : null;
+			string strETag = ExtractRawETag(objResponse);
 			return new Tuple<RunnersPointDocument, string>(objDocument, strETag);
 		}
 
@@ -445,7 +466,7 @@ namespace Chummer
 			{
 				HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Put, "/documents/" + strDocumentId);
 				objRequest.Headers.Add("Idempotency-Key", strIdempotencyKey);
-				objRequest.Headers.Add("If-Match", strIfMatch);
+				objRequest.Headers.TryAddWithoutValidation("If-Match", strIfMatch);
 				objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
 				objRequest.Headers.Add("X-Document-Format", strFormat);
 				objRequest.Content = new ByteArrayContent(bytContent);
@@ -604,7 +625,7 @@ namespace Chummer
 			{
 				HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Delete, "/documents/" + strDocumentId);
 				objRequest.Headers.Add("Idempotency-Key", strIdempotencyKey);
-				objRequest.Headers.Add("If-Match", strIfMatch);
+				objRequest.Headers.TryAddWithoutValidation("If-Match", strIfMatch);
 				return objRequest;
 			});
 			await ThrowIfProblemAsync(objResponse);
@@ -653,7 +674,7 @@ namespace Chummer
 			string strBody = await objResponse.Content.ReadAsStringAsync();
 			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
 			RunnersPointSharedDocument objDocument = ParseSharedDocument(objSerializer.Deserialize<Dictionary<string, object>>(strBody));
-			string strETag = objResponse.Headers.ETag != null ? objResponse.Headers.ETag.Tag : null;
+			string strETag = ExtractRawETag(objResponse);
 			return new Tuple<RunnersPointSharedDocument, string>(objDocument, strETag);
 		}
 
@@ -668,7 +689,7 @@ namespace Chummer
 			{
 				HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Put, "/shared/documents/" + strDocumentId);
 				objRequest.Headers.Add("Idempotency-Key", strIdempotencyKey);
-				objRequest.Headers.Add("If-Match", strIfMatch);
+				objRequest.Headers.TryAddWithoutValidation("If-Match", strIfMatch);
 				objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
 				objRequest.Headers.Add("X-Document-Format", strFormat);
 				objRequest.Content = new ByteArrayContent(bytContent);

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -721,5 +721,37 @@ namespace Chummer
 
 			return new Tuple<byte[], string>(bytContent, ParseSuggestedFileName(objResponse));
 		}
+
+#if DEBUG
+		/// <summary>
+		/// Debug-build-only diagnostic: dumps raw request/response detail for a document lookup that the
+		/// normal typed methods discard (the exact ETag header text, full response headers, raw metadata
+		/// JSON). Exists because bugs like the unquoted-ETag one are invisible through the typed API and
+		/// only show up by looking at the wire format directly.
+		/// </summary>
+		public async Task<string> GetDebugDumpAsync(string strDocumentId)
+		{
+			StringBuilder objDump = new StringBuilder();
+			objDump.AppendLine("Base URL: " + BaseUrl);
+			objDump.AppendLine("Client: " + ClientName + " " + System.Reflection.Assembly.GetExecutingAssembly().GetName().Version);
+
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/documents/" + strDocumentId);
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+
+			objDump.AppendLine();
+			objDump.AppendLine("GET /documents/" + strDocumentId);
+			objDump.AppendLine("Status: " + (int)objResponse.StatusCode + " " + objResponse.ReasonPhrase);
+			objDump.AppendLine("Response headers:");
+			foreach (KeyValuePair<string, IEnumerable<string>> objHeader in objResponse.Headers)
+				objDump.AppendLine("  " + objHeader.Key + ": " + string.Join(", ", objHeader.Value));
+			objDump.AppendLine("Headers.ETag (typed): " + (objResponse.Headers.ETag?.Tag ?? "(null - see ExtractRawETag)"));
+			objDump.AppendLine("ExtractRawETag(): " + (ExtractRawETag(objResponse) ?? "(null)"));
+
+			string strBody = await objResponse.Content.ReadAsStringAsync();
+			objDump.AppendLine("Body: " + strBody);
+
+			return objDump.ToString();
+		}
+#endif
 	}
 }

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -307,7 +307,7 @@ namespace Chummer
 			return objPage;
 		}
 
-		private static RunnersPointDocument ParseDocument(Dictionary<string, object> objJson)
+		internal static RunnersPointDocument ParseDocument(Dictionary<string, object> objJson)
 		{
 			RunnersPointDocument objDocument = new RunnersPointDocument();
 			objDocument.Id = objJson.ContainsKey("id") ? objJson["id"].ToString() : "";
@@ -332,7 +332,7 @@ namespace Chummer
 		/// Parses a SharedDocument - the same envelope as Document, plus a required `share` grant
 		/// (permission/status/expiresAt) describing what the authenticated user is allowed to do with it.
 		/// </summary>
-		private static RunnersPointSharedDocument ParseSharedDocument(Dictionary<string, object> objJson)
+		internal static RunnersPointSharedDocument ParseSharedDocument(Dictionary<string, object> objJson)
 		{
 			RunnersPointDocument objBase = ParseDocument(objJson);
 			RunnersPointSharedDocument objShared = new RunnersPointSharedDocument
@@ -478,10 +478,16 @@ namespace Chummer
 		/// one - not all deployments do (it's an optional hint per the spec), so callers should fall back
 		/// to something derived from the document's own metadata when this returns null.
 		/// </summary>
-		private static string ParseSuggestedFileName(HttpResponseMessage objResponse)
+		internal static string ParseSuggestedFileName(HttpResponseMessage objResponse)
 		{
+			// Content-Disposition is a content header per RFC 7231, not a response header - HttpClient
+			// parses it onto Content.Headers, never onto the top-level Headers collection, so looking
+			// there would never find it even if the server sent one.
+			if (objResponse.Content == null)
+				return null;
+
 			IEnumerable<string> lstValues;
-			if (!objResponse.Headers.TryGetValues("Content-Disposition", out lstValues))
+			if (!objResponse.Content.Headers.TryGetValues("Content-Disposition", out lstValues))
 				return null;
 
 			string strHeader = lstValues.FirstOrDefault();
@@ -504,7 +510,7 @@ namespace Chummer
 		/// "SHA-256 digest of the response bytes" without nailing down RFC 3230's usual
 		/// "SHA-256=&lt;base64&gt;" framing vs. a bare hex string, so both are accepted.
 		/// </summary>
-		private static bool VerifyDigest(byte[] bytContent, string strDigestHeader)
+		internal static bool VerifyDigest(byte[] bytContent, string strDigestHeader)
 		{
 			string strValue = strDigestHeader;
 			int intEquals = strValue.IndexOf('=');
@@ -516,21 +522,24 @@ namespace Chummer
 				bytExpected = objSha256.ComputeHash(bytContent);
 
 			byte[] bytActual;
-			try
+			string strHex = strValue.Replace("-", "");
+			// A bare hex SHA-256 digest is 64 lowercase-hex characters - which is also, incidentally, a
+			// syntactically valid (if semantically wrong) base64 string, since the hex alphabet is a
+			// subset of base64's and 64 is a multiple of 4. Trying base64 first would silently decode
+			// that into 48 wrong bytes instead of throwing, so hex-shaped input has to be checked first.
+			if (strHex.Length % 2 == 0 && System.Text.RegularExpressions.Regex.IsMatch(strHex, "^[0-9a-fA-F]+$"))
 			{
-				// Try base64 first (RFC 3230 convention), fall back to hex.
-				bytActual = Convert.FromBase64String(strValue);
+				bytActual = new byte[strHex.Length / 2];
+				for (int i = 0; i < bytActual.Length; i++)
+					bytActual[i] = Convert.ToByte(strHex.Substring(i * 2, 2), 16);
 			}
-			catch (FormatException)
+			else
 			{
 				try
 				{
-					string strHex = strValue.Replace("-", "");
-					bytActual = new byte[strHex.Length / 2];
-					for (int i = 0; i < bytActual.Length; i++)
-						bytActual[i] = Convert.ToByte(strHex.Substring(i * 2, 2), 16);
+					bytActual = Convert.FromBase64String(strValue);
 				}
-				catch
+				catch (FormatException)
 				{
 					// Header present but not in a format we understand - don't fail the download over
 					// a format mismatch we can't parse, but don't pretend we verified it either.

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -1,0 +1,372 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Script.Serialization;
+
+namespace Chummer
+{
+	/// <summary>
+	/// Document as returned by the RunnersPoint Character Document Storage API.
+	/// </summary>
+	public class RunnersPointDocument
+	{
+		public string Id { get; set; }
+		public string Type { get; set; }
+		public string GameProfileId { get; set; }
+		public string Format { get; set; }
+		public string SchemaVersion { get; set; }
+		public string CurrentRevision { get; set; }
+		public string ValidationState { get; set; }
+		public string DisplayName { get; set; }
+		public DateTime UpdatedAt { get; set; }
+	}
+
+	/// <summary>
+	/// A page of Documents from listDocuments, plus the ETag/cursor needed to keep paging.
+	/// </summary>
+	public class RunnersPointDocumentPage
+	{
+		public List<RunnersPointDocument> Items { get; set; } = new List<RunnersPointDocument>();
+		public string NextCursor { get; set; }
+	}
+
+	/// <summary>
+	/// Asynchronous quarantine/validation status, returned by createDocument, pushRevision, and getRevisionStatus.
+	/// </summary>
+	public class RunnersPointRevisionStatus
+	{
+		public string DocumentId { get; set; }
+		public string RevisionId { get; set; }
+		public string State { get; set; }
+		public List<string> Messages { get; set; } = new List<string>();
+	}
+
+	public class RunnersPointGameProfile
+	{
+		public string Id { get; set; }
+		public string System { get; set; }
+		public string Edition { get; set; }
+		public string DisplayName { get; set; }
+		public List<string> Formats { get; set; } = new List<string>();
+	}
+
+	public class RunnersPointCapabilities
+	{
+		public string ApiVersion { get; set; }
+		public List<RunnersPointGameProfile> GameProfiles { get; set; } = new List<RunnersPointGameProfile>();
+		public List<string> Formats { get; set; } = new List<string>();
+		public long MaximumUploadBytes { get; set; }
+	}
+
+	/// <summary>
+	/// Thrown for any non-success response from the RunnersPoint API. Carries the RFC 9457 Problem
+	/// Details fields where the server provided them, so callers can show a useful message instead of
+	/// just an HTTP status code.
+	/// </summary>
+	public class RunnersPointApiException : Exception
+	{
+		public HttpStatusCode StatusCode { get; private set; }
+		public string ProblemCode { get; private set; }
+		public string CorrelationId { get; private set; }
+
+		public RunnersPointApiException(HttpStatusCode statusCode, string title, string problemCode, string correlationId)
+			: base(title)
+		{
+			StatusCode = statusCode;
+			ProblemCode = problemCode;
+			CorrelationId = correlationId;
+		}
+	}
+
+	/// <summary>
+	/// Thin wrapper over the RunnersPoint Character Document Storage API (v1, draft.2). Only implements
+	/// the operations the Chummer client actually uses - personal storage/sync of `character` documents.
+	/// Sharing/discovery and non-character document types are out of scope for this client (see
+	/// docs/api/open-questions-character-document-storage-v1.md in the RunnersPoint repo).
+	/// </summary>
+	public class RunnersPointApiClient
+	{
+		// TODO: replace with the real base URL once RunnersPoint publishes one outside the example placeholder.
+		private const string BaseUrl = "https://api.runnerspoint.example/v1";
+		private const string ClientName = "ChummerGenSR4";
+
+		private readonly HttpClient _objHttpClient;
+		private readonly RunnersPointAuth _objAuth;
+
+		public RunnersPointApiClient(RunnersPointAuth objAuth)
+		{
+			_objAuth = objAuth;
+			_objHttpClient = new HttpClient();
+			_objHttpClient.DefaultRequestHeaders.Add("X-Client-Name", ClientName);
+			_objHttpClient.DefaultRequestHeaders.Add("X-Client-Version", System.Reflection.Assembly.GetExecutingAssembly().GetName().Version.ToString());
+		}
+
+		private async Task<HttpRequestMessage> CreateRequestAsync(HttpMethod objMethod, string strPath, bool blnAuthenticated = true)
+		{
+			HttpRequestMessage objRequest = new HttpRequestMessage(objMethod, BaseUrl + strPath);
+			if (blnAuthenticated)
+			{
+				string strToken = await _objAuth.GetAccessTokenAsync();
+				objRequest.Headers.Authorization = new AuthenticationHeaderValue("Bearer", strToken);
+			}
+			return objRequest;
+		}
+
+		private static string NewIdempotencyKey()
+		{
+			return Guid.NewGuid().ToString("N");
+		}
+
+		private async Task ThrowIfProblemAsync(HttpResponseMessage objResponse)
+		{
+			if (objResponse.IsSuccessStatusCode)
+				return;
+
+			string strTitle = objResponse.ReasonPhrase;
+			string strCode = "";
+			string strCorrelationId = "";
+			try
+			{
+				string strBody = await objResponse.Content.ReadAsStringAsync();
+				if (!string.IsNullOrEmpty(strBody))
+				{
+					JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+					Dictionary<string, object> objProblem = objSerializer.Deserialize<Dictionary<string, object>>(strBody);
+					if (objProblem.ContainsKey("title"))
+						strTitle = objProblem["title"].ToString();
+					if (objProblem.ContainsKey("code"))
+						strCode = objProblem["code"].ToString();
+					if (objProblem.ContainsKey("correlationId"))
+						strCorrelationId = objProblem["correlationId"].ToString();
+				}
+			}
+			catch
+			{
+				// Problem body wasn't valid JSON (or wasn't Problem-shaped) - fall back to the status line.
+			}
+
+			if (objResponse.StatusCode == (HttpStatusCode)429)
+			{
+				IEnumerable<string> lstRetryAfter;
+				string strRetryAfter = objResponse.Headers.TryGetValues("Retry-After", out lstRetryAfter) ? string.Join(",", lstRetryAfter) : "unknown";
+				throw new RunnersPointApiException(objResponse.StatusCode, "Rate limited - retry after " + strRetryAfter + "s", strCode, strCorrelationId);
+			}
+
+			throw new RunnersPointApiException(objResponse.StatusCode, strTitle, strCode, strCorrelationId);
+		}
+
+		/// <summary>
+		/// GET /capabilities. Unauthenticated. Used at startup to resolve the SR4 GameProfileId and its
+		/// supported formats/maximum upload size.
+		/// </summary>
+		public async Task<RunnersPointCapabilities> GetCapabilitiesAsync()
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/capabilities", false);
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+
+			string strBody = await objResponse.Content.ReadAsStringAsync();
+			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+			Dictionary<string, object> objJson = objSerializer.Deserialize<Dictionary<string, object>>(strBody);
+
+			RunnersPointCapabilities objCapabilities = new RunnersPointCapabilities();
+			objCapabilities.ApiVersion = objJson.ContainsKey("apiVersion") ? objJson["apiVersion"].ToString() : "";
+			objCapabilities.MaximumUploadBytes = objJson.ContainsKey("maximumUploadBytes") ? Convert.ToInt64(objJson["maximumUploadBytes"]) : 0;
+
+			if (objJson.ContainsKey("formats"))
+			{
+				foreach (object objFormat in (object[])objJson["formats"])
+					objCapabilities.Formats.Add(objFormat.ToString());
+			}
+
+			if (objJson.ContainsKey("gameProfiles"))
+			{
+				foreach (object objProfileObj in (object[])objJson["gameProfiles"])
+				{
+					Dictionary<string, object> objProfile = (Dictionary<string, object>)objProfileObj;
+					RunnersPointGameProfile objGameProfile = new RunnersPointGameProfile();
+					objGameProfile.Id = objProfile.ContainsKey("id") ? objProfile["id"].ToString() : "";
+					objGameProfile.System = objProfile.ContainsKey("system") ? objProfile["system"].ToString() : "";
+					objGameProfile.Edition = objProfile.ContainsKey("edition") ? objProfile["edition"].ToString() : "";
+					objGameProfile.DisplayName = objProfile.ContainsKey("displayName") ? objProfile["displayName"].ToString() : "";
+					if (objProfile.ContainsKey("formats"))
+					{
+						foreach (object objFormat in (object[])objProfile["formats"])
+							objGameProfile.Formats.Add(objFormat.ToString());
+					}
+					objCapabilities.GameProfiles.Add(objGameProfile);
+				}
+			}
+
+			return objCapabilities;
+		}
+
+		/// <summary>
+		/// GET /documents. Documents owned by the authenticated user, optionally filtered.
+		/// </summary>
+		public async Task<RunnersPointDocumentPage> ListDocumentsAsync(string strGameProfileId, string strCursor = null, int intPageSize = 25)
+		{
+			string strPath = "/documents?gameProfileId=" + Uri.EscapeDataString(strGameProfileId) + "&pageSize=" + intPageSize;
+			if (!string.IsNullOrEmpty(strCursor))
+				strPath += "&cursor=" + Uri.EscapeDataString(strCursor);
+
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, strPath);
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+
+			string strBody = await objResponse.Content.ReadAsStringAsync();
+			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+			Dictionary<string, object> objJson = objSerializer.Deserialize<Dictionary<string, object>>(strBody);
+
+			RunnersPointDocumentPage objPage = new RunnersPointDocumentPage();
+			objPage.NextCursor = objJson.ContainsKey("nextCursor") && objJson["nextCursor"] != null ? objJson["nextCursor"].ToString() : null;
+
+			if (objJson.ContainsKey("items"))
+			{
+				foreach (object objItemObj in (object[])objJson["items"])
+					objPage.Items.Add(ParseDocument((Dictionary<string, object>)objItemObj));
+			}
+
+			return objPage;
+		}
+
+		private static RunnersPointDocument ParseDocument(Dictionary<string, object> objJson)
+		{
+			RunnersPointDocument objDocument = new RunnersPointDocument();
+			objDocument.Id = objJson.ContainsKey("id") ? objJson["id"].ToString() : "";
+			objDocument.Type = objJson.ContainsKey("type") ? objJson["type"].ToString() : "";
+			objDocument.GameProfileId = objJson.ContainsKey("gameProfileId") ? objJson["gameProfileId"].ToString() : "";
+			objDocument.Format = objJson.ContainsKey("format") ? objJson["format"].ToString() : "";
+			objDocument.SchemaVersion = objJson.ContainsKey("schemaVersion") ? objJson["schemaVersion"].ToString() : "";
+			objDocument.CurrentRevision = objJson.ContainsKey("currentRevision") ? objJson["currentRevision"].ToString() : "";
+			objDocument.ValidationState = objJson.ContainsKey("validationState") ? objJson["validationState"].ToString() : "";
+			if (objJson.ContainsKey("metadata") && objJson["metadata"] is Dictionary<string, object>)
+			{
+				Dictionary<string, object> objMetadata = (Dictionary<string, object>)objJson["metadata"];
+				if (objMetadata.ContainsKey("displayName"))
+					objDocument.DisplayName = objMetadata["displayName"].ToString();
+			}
+			if (objJson.ContainsKey("updatedAt"))
+				DateTime.TryParse(objJson["updatedAt"].ToString(), out DateTime datUpdatedAt);
+			return objDocument;
+		}
+
+		/// <summary>
+		/// GET /documents/{documentId}. Returns the document plus its current ETag (needed for a
+		/// subsequent pushRevision/archive call's If-Match).
+		/// </summary>
+		public async Task<Tuple<RunnersPointDocument, string>> GetDocumentAsync(string strDocumentId)
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/documents/" + strDocumentId);
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+
+			string strBody = await objResponse.Content.ReadAsStringAsync();
+			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+			RunnersPointDocument objDocument = ParseDocument(objSerializer.Deserialize<Dictionary<string, object>>(strBody));
+			string strETag = objResponse.Headers.ETag != null ? objResponse.Headers.ETag.Tag : null;
+			return new Tuple<RunnersPointDocument, string>(objDocument, strETag);
+		}
+
+		/// <summary>
+		/// POST /documents. Mints a brand-new document and its first revision. Do not call this again
+		/// for a document that already has a CloudDocumentId - use PushRevisionAsync instead.
+		/// </summary>
+		public async Task<RunnersPointRevisionStatus> CreateDocumentAsync(byte[] bytContent, string strGameProfileId, string strFormat)
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Post, "/documents");
+			objRequest.Headers.Add("Idempotency-Key", NewIdempotencyKey());
+			objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
+			objRequest.Headers.Add("X-Document-Format", strFormat);
+			objRequest.Content = new ByteArrayContent(bytContent);
+			objRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+			return await ParseRevisionStatusAsync(objResponse);
+		}
+
+		/// <summary>
+		/// PUT /documents/{documentId}. Pushes new content for a document that already exists. The
+		/// server hash-checks against existing revisions; identical content returns the existing
+		/// revision rather than creating a duplicate. Requires the document's current ETag - a stale
+		/// strIfMatch results in a RunnersPointApiException with StatusCode 412, meaning the caller
+		/// should GetDocumentAsync for the latest ETag/content before retrying.
+		/// </summary>
+		public async Task<RunnersPointRevisionStatus> PushRevisionAsync(string strDocumentId, byte[] bytContent, string strIfMatch, string strGameProfileId, string strFormat)
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Put, "/documents/" + strDocumentId);
+			objRequest.Headers.Add("Idempotency-Key", NewIdempotencyKey());
+			objRequest.Headers.Add("If-Match", strIfMatch);
+			objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
+			objRequest.Headers.Add("X-Document-Format", strFormat);
+			objRequest.Content = new ByteArrayContent(bytContent);
+			objRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+			return await ParseRevisionStatusAsync(objResponse);
+		}
+
+		private async Task<RunnersPointRevisionStatus> ParseRevisionStatusAsync(HttpResponseMessage objResponse)
+		{
+			string strBody = await objResponse.Content.ReadAsStringAsync();
+			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+			Dictionary<string, object> objJson = objSerializer.Deserialize<Dictionary<string, object>>(strBody);
+
+			RunnersPointRevisionStatus objStatus = new RunnersPointRevisionStatus();
+			objStatus.DocumentId = objJson.ContainsKey("documentId") ? objJson["documentId"].ToString() : "";
+			objStatus.RevisionId = objJson.ContainsKey("revisionId") ? objJson["revisionId"].ToString() : "";
+			objStatus.State = objJson.ContainsKey("state") ? objJson["state"].ToString() : "";
+			if (objJson.ContainsKey("messages"))
+			{
+				foreach (object objMessage in (object[])objJson["messages"])
+					objStatus.Messages.Add(objMessage.ToString());
+			}
+			return objStatus;
+		}
+
+		/// <summary>
+		/// GET /revision-status/{revisionId}. Called on-demand (e.g. when the user opens the Cloud
+		/// Documents panel) - Chummer does not poll this in the background.
+		/// </summary>
+		public async Task<RunnersPointRevisionStatus> GetRevisionStatusAsync(string strRevisionId)
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/revision-status/" + strRevisionId);
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+			return await ParseRevisionStatusAsync(objResponse);
+		}
+
+		/// <summary>
+		/// GET /documents/{documentId}/revisions/{revisionId}/content. Downloads the accepted bytes
+		/// for a specific revision (used to pull a document down to a new local .chum file).
+		/// </summary>
+		public async Task<byte[]> DownloadRevisionAsync(string strDocumentId, string strRevisionId)
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/documents/" + strDocumentId + "/revisions/" + strRevisionId + "/content");
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+			return await objResponse.Content.ReadAsByteArrayAsync();
+		}
+
+		/// <summary>
+		/// DELETE /documents/{documentId}. Archives the document per the server's retention policy.
+		/// Requires the document's current ETag, same staleness handling as PushRevisionAsync.
+		/// </summary>
+		public async Task ArchiveDocumentAsync(string strDocumentId, string strIfMatch)
+		{
+			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Delete, "/documents/" + strDocumentId);
+			objRequest.Headers.Add("Idempotency-Key", NewIdempotencyKey());
+			objRequest.Headers.Add("If-Match", strIfMatch);
+
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			await ThrowIfProblemAsync(objResponse);
+		}
+	}
+}

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -114,8 +114,11 @@ namespace Chummer
 	/// </summary>
 	public class RunnersPointApiClient
 	{
-		// TODO: replace with the real base URL once RunnersPoint publishes one outside the example placeholder.
-		private const string BaseUrl = "https://api.runnerspoint.example/v1";
+		// Configurable via Options > Cloud Documents server (GlobalOptions.CloudApiBaseUrl), so it can
+		// point at a local dev server, a staging deployment, or eventually a real production host
+		// without a rebuild. Defaults to the local Symfony dev server's actual route prefix (/api/v1,
+		// not the /v1 the OpenAPI spec's example server URL still shows).
+		private static string BaseUrl => GlobalOptions.Instance.CloudApiBaseUrl;
 		private const string ClientName = "ChummerGenSR4";
 
 		private readonly HttpClient _objHttpClient;

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -172,6 +172,32 @@ namespace Chummer
 			return Guid.NewGuid().ToString("N");
 		}
 
+		/// <summary>
+		/// Sends an authenticated request built by requestFactory. If the server responds 401, forces a
+		/// token refresh and retries once with a freshly-built request (a request/its content can't be
+		/// resent as-is once sent, hence rebuilding rather than reusing the same HttpRequestMessage). If
+		/// there's nothing to refresh (a pasted apiToken) or the refresh itself fails, the original 401
+		/// response is returned as-is for ThrowIfProblemAsync to turn into the usual auth-expired path.
+		/// requestFactory must be safe to call twice - callers building a POST/PUT with a stable
+		/// Idempotency-Key should compute that key once, outside the factory, and only rebuild the
+		/// request/content inside it.
+		/// </summary>
+		private async Task<HttpResponseMessage> SendWithRetryAsync(Func<Task<HttpRequestMessage>> requestFactory)
+		{
+			HttpRequestMessage objRequest = await requestFactory();
+			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			if (objResponse.StatusCode != HttpStatusCode.Unauthorized)
+				return objResponse;
+
+			if (!await _objAuth.TryForceRefreshAsync())
+				return objResponse;
+
+			Log.Information("RunnersPoint API call got 401 - refreshed the access token and retrying once");
+			objResponse.Dispose();
+			HttpRequestMessage objRetryRequest = await requestFactory();
+			return await _objHttpClient.SendAsync(objRetryRequest);
+		}
+
 		private async Task ThrowIfProblemAsync(HttpResponseMessage objResponse)
 		{
 			if (objResponse.IsSuccessStatusCode)
@@ -295,8 +321,7 @@ namespace Chummer
 			if (!string.IsNullOrEmpty(strCursor))
 				strPath += "&cursor=" + Uri.EscapeDataString(strCursor);
 
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, strPath);
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			HttpResponseMessage objResponse = await SendWithRetryAsync(() => CreateRequestAsync(HttpMethod.Get, strPath));
 			await ThrowIfProblemAsync(objResponse);
 
 			string strBody = await objResponse.Content.ReadAsStringAsync();
@@ -374,8 +399,7 @@ namespace Chummer
 		/// </summary>
 		public async Task<Tuple<RunnersPointDocument, string>> GetDocumentAsync(string strDocumentId)
 		{
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/documents/" + strDocumentId);
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			HttpResponseMessage objResponse = await SendWithRetryAsync(() => CreateRequestAsync(HttpMethod.Get, "/documents/" + strDocumentId));
 			await ThrowIfProblemAsync(objResponse);
 
 			string strBody = await objResponse.Content.ReadAsStringAsync();
@@ -391,15 +415,18 @@ namespace Chummer
 		/// </summary>
 		public async Task<RunnersPointRevisionStatus> CreateDocumentAsync(byte[] bytContent, string strGameProfileId, string strFormat)
 		{
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Post, "/documents");
-			objRequest.Headers.Add("Idempotency-Key", NewIdempotencyKey());
-			objRequest.Headers.Add("X-Document-Type", "character");
-			objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
-			objRequest.Headers.Add("X-Document-Format", strFormat);
-			objRequest.Content = new ByteArrayContent(bytContent);
-			objRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			string strIdempotencyKey = NewIdempotencyKey();
+			HttpResponseMessage objResponse = await SendWithRetryAsync(async () =>
+			{
+				HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Post, "/documents");
+				objRequest.Headers.Add("Idempotency-Key", strIdempotencyKey);
+				objRequest.Headers.Add("X-Document-Type", "character");
+				objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
+				objRequest.Headers.Add("X-Document-Format", strFormat);
+				objRequest.Content = new ByteArrayContent(bytContent);
+				objRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+				return objRequest;
+			});
 			await ThrowIfProblemAsync(objResponse);
 			return await ParseRevisionStatusAsync(objResponse);
 		}
@@ -413,15 +440,18 @@ namespace Chummer
 		/// </summary>
 		public async Task<RunnersPointRevisionStatus> PushRevisionAsync(string strDocumentId, byte[] bytContent, string strIfMatch, string strGameProfileId, string strFormat)
 		{
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Put, "/documents/" + strDocumentId);
-			objRequest.Headers.Add("Idempotency-Key", NewIdempotencyKey());
-			objRequest.Headers.Add("If-Match", strIfMatch);
-			objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
-			objRequest.Headers.Add("X-Document-Format", strFormat);
-			objRequest.Content = new ByteArrayContent(bytContent);
-			objRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			string strIdempotencyKey = NewIdempotencyKey();
+			HttpResponseMessage objResponse = await SendWithRetryAsync(async () =>
+			{
+				HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Put, "/documents/" + strDocumentId);
+				objRequest.Headers.Add("Idempotency-Key", strIdempotencyKey);
+				objRequest.Headers.Add("If-Match", strIfMatch);
+				objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
+				objRequest.Headers.Add("X-Document-Format", strFormat);
+				objRequest.Content = new ByteArrayContent(bytContent);
+				objRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+				return objRequest;
+			});
 			await ThrowIfProblemAsync(objResponse);
 			return await ParseRevisionStatusAsync(objResponse);
 		}
@@ -450,8 +480,7 @@ namespace Chummer
 		/// </summary>
 		public async Task<RunnersPointRevisionStatus> GetRevisionStatusAsync(string strRevisionId)
 		{
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/revision-status/" + strRevisionId);
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			HttpResponseMessage objResponse = await SendWithRetryAsync(() => CreateRequestAsync(HttpMethod.Get, "/revision-status/" + strRevisionId));
 			await ThrowIfProblemAsync(objResponse);
 			return await ParseRevisionStatusAsync(objResponse);
 		}
@@ -465,8 +494,7 @@ namespace Chummer
 		/// </summary>
 		public async Task<Tuple<byte[], string>> DownloadRevisionAsync(string strDocumentId, string strRevisionId)
 		{
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/documents/" + strDocumentId + "/revisions/" + strRevisionId + "/content");
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			HttpResponseMessage objResponse = await SendWithRetryAsync(() => CreateRequestAsync(HttpMethod.Get, "/documents/" + strDocumentId + "/revisions/" + strRevisionId + "/content"));
 			await ThrowIfProblemAsync(objResponse);
 			byte[] bytContent = await objResponse.Content.ReadAsByteArrayAsync();
 
@@ -571,11 +599,14 @@ namespace Chummer
 		/// </summary>
 		public async Task ArchiveDocumentAsync(string strDocumentId, string strIfMatch)
 		{
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Delete, "/documents/" + strDocumentId);
-			objRequest.Headers.Add("Idempotency-Key", NewIdempotencyKey());
-			objRequest.Headers.Add("If-Match", strIfMatch);
-
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			string strIdempotencyKey = NewIdempotencyKey();
+			HttpResponseMessage objResponse = await SendWithRetryAsync(async () =>
+			{
+				HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Delete, "/documents/" + strDocumentId);
+				objRequest.Headers.Add("Idempotency-Key", strIdempotencyKey);
+				objRequest.Headers.Add("If-Match", strIfMatch);
+				return objRequest;
+			});
 			await ThrowIfProblemAsync(objResponse);
 		}
 
@@ -591,8 +622,7 @@ namespace Chummer
 			if (!string.IsNullOrEmpty(strCursor))
 				strPath += "&cursor=" + Uri.EscapeDataString(strCursor);
 
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, strPath);
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			HttpResponseMessage objResponse = await SendWithRetryAsync(() => CreateRequestAsync(HttpMethod.Get, strPath));
 			await ThrowIfProblemAsync(objResponse);
 
 			string strBody = await objResponse.Content.ReadAsStringAsync();
@@ -617,8 +647,7 @@ namespace Chummer
 		/// </summary>
 		public async Task<Tuple<RunnersPointSharedDocument, string>> GetSharedDocumentAsync(string strDocumentId)
 		{
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/shared/documents/" + strDocumentId);
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			HttpResponseMessage objResponse = await SendWithRetryAsync(() => CreateRequestAsync(HttpMethod.Get, "/shared/documents/" + strDocumentId));
 			await ThrowIfProblemAsync(objResponse);
 
 			string strBody = await objResponse.Content.ReadAsStringAsync();
@@ -634,15 +663,18 @@ namespace Chummer
 		/// </summary>
 		public async Task<RunnersPointRevisionStatus> PushSharedDocumentRevisionAsync(string strDocumentId, byte[] bytContent, string strIfMatch, string strGameProfileId, string strFormat)
 		{
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Put, "/shared/documents/" + strDocumentId);
-			objRequest.Headers.Add("Idempotency-Key", NewIdempotencyKey());
-			objRequest.Headers.Add("If-Match", strIfMatch);
-			objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
-			objRequest.Headers.Add("X-Document-Format", strFormat);
-			objRequest.Content = new ByteArrayContent(bytContent);
-			objRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
-
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			string strIdempotencyKey = NewIdempotencyKey();
+			HttpResponseMessage objResponse = await SendWithRetryAsync(async () =>
+			{
+				HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Put, "/shared/documents/" + strDocumentId);
+				objRequest.Headers.Add("Idempotency-Key", strIdempotencyKey);
+				objRequest.Headers.Add("If-Match", strIfMatch);
+				objRequest.Headers.Add("X-Game-Profile-Id", strGameProfileId);
+				objRequest.Headers.Add("X-Document-Format", strFormat);
+				objRequest.Content = new ByteArrayContent(bytContent);
+				objRequest.Content.Headers.ContentType = new MediaTypeHeaderValue("application/octet-stream");
+				return objRequest;
+			});
 			await ThrowIfProblemAsync(objResponse);
 			return await ParseRevisionStatusAsync(objResponse);
 		}
@@ -654,8 +686,7 @@ namespace Chummer
 		/// </summary>
 		public async Task<Tuple<byte[], string>> DownloadSharedDocumentRevisionAsync(string strDocumentId, string strRevisionId)
 		{
-			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/shared/documents/" + strDocumentId + "/revisions/" + strRevisionId + "/content");
-			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
+			HttpResponseMessage objResponse = await SendWithRetryAsync(() => CreateRequestAsync(HttpMethod.Get, "/shared/documents/" + strDocumentId + "/revisions/" + strRevisionId + "/content"));
 			await ThrowIfProblemAsync(objResponse);
 			byte[] bytContent = await objResponse.Content.ReadAsByteArrayAsync();
 

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web.Script.Serialization;
@@ -345,14 +347,76 @@ namespace Chummer
 
 		/// <summary>
 		/// GET /documents/{documentId}/revisions/{revisionId}/content. Downloads the accepted bytes
-		/// for a specific revision (used to pull a document down to a new local .chum file).
+		/// for a specific revision (used to pull a document down to a new local .chum file). Verifies
+		/// the response's Digest header (SHA-256 of the bytes) against what was actually received,
+		/// since silently trusting an unverified download for a "store my character" feature is asking
+		/// for a corrupted/truncated file to go unnoticed.
 		/// </summary>
 		public async Task<byte[]> DownloadRevisionAsync(string strDocumentId, string strRevisionId)
 		{
 			HttpRequestMessage objRequest = await CreateRequestAsync(HttpMethod.Get, "/documents/" + strDocumentId + "/revisions/" + strRevisionId + "/content");
 			HttpResponseMessage objResponse = await _objHttpClient.SendAsync(objRequest);
 			await ThrowIfProblemAsync(objResponse);
-			return await objResponse.Content.ReadAsByteArrayAsync();
+			byte[] bytContent = await objResponse.Content.ReadAsByteArrayAsync();
+
+			IEnumerable<string> lstDigestValues;
+			if (objResponse.Headers.TryGetValues("Digest", out lstDigestValues))
+			{
+				string strDigestHeader = lstDigestValues.FirstOrDefault();
+				if (!string.IsNullOrEmpty(strDigestHeader) && !VerifyDigest(bytContent, strDigestHeader))
+					throw new InvalidOperationException("Downloaded content for revision " + strRevisionId + " failed digest verification - the bytes received don't match the server's declared hash. Discarding rather than saving a possibly-corrupted file.");
+			}
+
+			return bytContent;
+		}
+
+		/// <summary>
+		/// Compares a SHA-256 hash of bytContent against a Digest header value. The spec only says
+		/// "SHA-256 digest of the response bytes" without nailing down RFC 3230's usual
+		/// "SHA-256=&lt;base64&gt;" framing vs. a bare hex string, so both are accepted.
+		/// </summary>
+		private static bool VerifyDigest(byte[] bytContent, string strDigestHeader)
+		{
+			string strValue = strDigestHeader;
+			int intEquals = strValue.IndexOf('=');
+			if (strValue.StartsWith("SHA-256=", StringComparison.OrdinalIgnoreCase) && intEquals >= 0)
+				strValue = strValue.Substring(intEquals + 1);
+
+			byte[] bytExpected;
+			using (SHA256 objSha256 = SHA256.Create())
+				bytExpected = objSha256.ComputeHash(bytContent);
+
+			byte[] bytActual;
+			try
+			{
+				// Try base64 first (RFC 3230 convention), fall back to hex.
+				bytActual = Convert.FromBase64String(strValue);
+			}
+			catch (FormatException)
+			{
+				try
+				{
+					string strHex = strValue.Replace("-", "");
+					bytActual = new byte[strHex.Length / 2];
+					for (int i = 0; i < bytActual.Length; i++)
+						bytActual[i] = Convert.ToByte(strHex.Substring(i * 2, 2), 16);
+				}
+				catch
+				{
+					// Header present but not in a format we understand - don't fail the download over
+					// a format mismatch we can't parse, but don't pretend we verified it either.
+					return true;
+				}
+			}
+
+			if (bytActual.Length != bytExpected.Length)
+				return false;
+			for (int i = 0; i < bytActual.Length; i++)
+			{
+				if (bytActual[i] != bytExpected[i])
+					return false;
+			}
+			return true;
 		}
 
 		/// <summary>

--- a/Chummer/code/clsRunnersPointApiClient.cs
+++ b/Chummer/code/clsRunnersPointApiClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -9,6 +10,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using System.Web.Script.Serialization;
+using Serilog;
 
 namespace Chummer
 {
@@ -198,13 +200,19 @@ namespace Chummer
 				// Problem body wasn't valid JSON (or wasn't Problem-shaped) - fall back to the status line.
 			}
 
+			string strMethod = objResponse.RequestMessage?.Method?.Method ?? "?";
+			string strPath = objResponse.RequestMessage?.RequestUri?.PathAndQuery ?? "?";
+
 			if (objResponse.StatusCode == (HttpStatusCode)429)
 			{
 				IEnumerable<string> lstRetryAfter;
 				string strRetryAfter = objResponse.Headers.TryGetValues("Retry-After", out lstRetryAfter) ? string.Join(",", lstRetryAfter) : "unknown";
+				Log.Warning("RunnersPoint API {Method} {Path} rate limited - retry after {RetryAfter}s (correlationId={CorrelationId})", strMethod, strPath, strRetryAfter, strCorrelationId);
 				throw new RunnersPointApiException(objResponse.StatusCode, "Rate limited - retry after " + strRetryAfter + "s", strCode, strCorrelationId);
 			}
 
+			Log.Warning("RunnersPoint API {Method} {Path} failed with {StatusCode}: {Title} (code={Code}, correlationId={CorrelationId})",
+				strMethod, strPath, (int)objResponse.StatusCode, strTitle, strCode, strCorrelationId);
 			throw new RunnersPointApiException(objResponse.StatusCode, strTitle, strCode, strCorrelationId);
 		}
 
@@ -228,13 +236,13 @@ namespace Chummer
 
 			if (objJson.ContainsKey("formats"))
 			{
-				foreach (object objFormat in (object[])objJson["formats"])
+				foreach (object objFormat in (IEnumerable)objJson["formats"])
 					objCapabilities.Formats.Add(objFormat.ToString());
 			}
 
 			if (objJson.ContainsKey("gameProfiles"))
 			{
-				foreach (object objProfileObj in (object[])objJson["gameProfiles"])
+				foreach (object objProfileObj in (IEnumerable)objJson["gameProfiles"])
 				{
 					Dictionary<string, object> objProfile = (Dictionary<string, object>)objProfileObj;
 					RunnersPointGameProfile objGameProfile = new RunnersPointGameProfile();
@@ -244,7 +252,7 @@ namespace Chummer
 					objGameProfile.DisplayName = objProfile.ContainsKey("displayName") ? objProfile["displayName"].ToString() : "";
 					if (objProfile.ContainsKey("formats"))
 					{
-						foreach (object objFormat in (object[])objProfile["formats"])
+						foreach (object objFormat in (IEnumerable)objProfile["formats"])
 							objGameProfile.Formats.Add(objFormat.ToString());
 					}
 					objCapabilities.GameProfiles.Add(objGameProfile);
@@ -253,7 +261,7 @@ namespace Chummer
 
 			if (objJson.ContainsKey("documentTypes"))
 			{
-				foreach (object objTypeObj in (object[])objJson["documentTypes"])
+				foreach (object objTypeObj in (IEnumerable)objJson["documentTypes"])
 				{
 					Dictionary<string, object> objType = (Dictionary<string, object>)objTypeObj;
 					RunnersPointDocumentTypeCapability objTypeCapability = new RunnersPointDocumentTypeCapability();
@@ -261,7 +269,7 @@ namespace Chummer
 					objTypeCapability.DisplayName = objType.ContainsKey("displayName") ? objType["displayName"].ToString() : "";
 					if (objType.ContainsKey("formats"))
 					{
-						foreach (object objFormatObj in (object[])objType["formats"])
+						foreach (object objFormatObj in (IEnumerable)objType["formats"])
 						{
 							Dictionary<string, object> objFormat = (Dictionary<string, object>)objFormatObj;
 							objTypeCapability.Formats.Add(new RunnersPointDocumentFormatCapability
@@ -300,7 +308,7 @@ namespace Chummer
 
 			if (objJson.ContainsKey("items"))
 			{
-				foreach (object objItemObj in (object[])objJson["items"])
+				foreach (object objItemObj in (IEnumerable)objJson["items"])
 					objPage.Items.Add(ParseDocument((Dictionary<string, object>)objItemObj));
 			}
 
@@ -430,7 +438,7 @@ namespace Chummer
 			objStatus.State = objJson.ContainsKey("state") ? objJson["state"].ToString() : "";
 			if (objJson.ContainsKey("messages"))
 			{
-				foreach (object objMessage in (object[])objJson["messages"])
+				foreach (object objMessage in (IEnumerable)objJson["messages"])
 					objStatus.Messages.Add(objMessage.ToString());
 			}
 			return objStatus;
@@ -596,7 +604,7 @@ namespace Chummer
 
 			if (objJson.ContainsKey("items"))
 			{
-				foreach (object objItemObj in (object[])objJson["items"])
+				foreach (object objItemObj in (IEnumerable)objJson["items"])
 					objPage.Items.Add(ParseSharedDocument((Dictionary<string, object>)objItemObj));
 			}
 

--- a/Chummer/code/clsRunnersPointAuth.cs
+++ b/Chummer/code/clsRunnersPointAuth.cs
@@ -29,7 +29,7 @@ namespace Chummer
 		private const string ClientId = "chummer-desktop-TODO";
 		private const string AuthorizationUrl = "https://accounts.runnerspoint.example/oauth/authorize";
 		private const string TokenUrl = "https://accounts.runnerspoint.example/oauth/token";
-		private const string Scopes = "documents:read documents:write";
+		private const string Scopes = "documents:read documents:write shared_documents:read shared_documents:write";
 
 		private static string TokenFilePath
 		{

--- a/Chummer/code/clsRunnersPointAuth.cs
+++ b/Chummer/code/clsRunnersPointAuth.cs
@@ -182,6 +182,31 @@ namespace Chummer
 			return _objCachedTokens.AccessToken;
 		}
 
+		/// <summary>
+		/// Forces a token refresh regardless of the locally-tracked expiry, for retrying a request that
+		/// the server itself just rejected with 401 (the local expiry clock and the server's may have
+		/// drifted, or the access token could have been revoked independently of its stated lifetime).
+		/// Returns false without throwing for anything that can't be refreshed this way - a pasted
+		/// apiToken (no refresh token at all) or a refresh attempt that itself fails - so callers can
+		/// fall back to treating the login as dead.
+		/// </summary>
+		public async Task<bool> TryForceRefreshAsync()
+		{
+			TokenSet objTokens = LoadTokens();
+			if (objTokens == null || objTokens.IsApiToken || string.IsNullOrEmpty(objTokens.RefreshToken))
+				return false;
+
+			try
+			{
+				await RefreshTokensAsync(objTokens);
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
 		private async Task ExchangeCodeForTokensAsync(string strCode, string strCodeVerifier, string strRedirectUri)
 		{
 			Dictionary<string, string> objFormData = new Dictionary<string, string>

--- a/Chummer/code/clsRunnersPointAuth.cs
+++ b/Chummer/code/clsRunnersPointAuth.cs
@@ -73,6 +73,16 @@ namespace Chummer
 		}
 
 		/// <summary>
+		/// Whether the current stored login (if any) is a pasted apiToken rather than an OAuth login.
+		/// Meaningless if HasStoredLogin() is false.
+		/// </summary>
+		public bool IsApiTokenLogin()
+		{
+			TokenSet objTokens = LoadTokens();
+			return objTokens != null && objTokens.IsApiToken;
+		}
+
+		/// <summary>
 		/// Runs the full interactive login flow: opens the system browser, listens on a loopback port
 		/// for the redirect, exchanges the code for tokens, and persists them.
 		/// </summary>
@@ -248,7 +258,10 @@ namespace Chummer
 
 			TokenSet objTokens = new TokenSet();
 			objTokens.AccessToken = objJson["accessToken"].ToString();
-			objTokens.RefreshToken = objJson.ContainsKey("refreshToken") ? objJson["refreshToken"].ToString() : null;
+			// apiToken logins always store a null RefreshToken - the "refreshToken" key is still present
+			// in the JSON with a JSON null value, so ContainsKey alone isn't enough to know it's safe to
+			// call .ToString() on it.
+			objTokens.RefreshToken = objJson.ContainsKey("refreshToken") && objJson["refreshToken"] != null ? objJson["refreshToken"].ToString() : null;
 			objTokens.ExpiresAtUtc = DateTime.Parse(objJson["expiresAtUtc"].ToString()).ToUniversalTime();
 			objTokens.IsApiToken = objJson.ContainsKey("isApiToken") && Convert.ToBoolean(objJson["isApiToken"]);
 

--- a/Chummer/code/clsRunnersPointAuth.cs
+++ b/Chummer/code/clsRunnersPointAuth.cs
@@ -1,0 +1,296 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using System.Web.Script.Serialization;
+
+namespace Chummer
+{
+	/// <summary>
+	/// OAuth2 Authorization Code + PKCE flow for the RunnersPoint API, plus token persistence. Chummer
+	/// is distributed as a public client (no embeddable secret), so this uses PKCE with a loopback
+	/// redirect and the system browser - the standard pattern for native/desktop OAuth clients.
+	///
+	/// Token storage: DPAPI-protected on Windows (CurrentUser scope, so only the OS account that logged
+	/// in can decrypt it). On non-Windows platforms (Mono/Linux) there is currently no equivalent secret
+	/// store wired up - tokens are written in plain text with a best-effort 0600 permission attempt, and
+	/// GetAccessTokenAsync surfaces a warning the first time it has to do this. A real Linux secret store
+	/// (e.g. libsecret) is tracked as follow-up work, not implemented here.
+	/// </summary>
+	public class RunnersPointAuth
+	{
+		// TODO: replace with Chummer's real registered public client id once RunnersPoint issues one.
+		private const string ClientId = "chummer-desktop-TODO";
+		private const string AuthorizationUrl = "https://accounts.runnerspoint.example/oauth/authorize";
+		private const string TokenUrl = "https://accounts.runnerspoint.example/oauth/token";
+		private const string Scopes = "documents:read documents:write";
+
+		private static string TokenFilePath
+		{
+			get
+			{
+				string strDir = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "ChummerGenSR4");
+				if (!Directory.Exists(strDir))
+					Directory.CreateDirectory(strDir);
+				return Path.Combine(strDir, "cloudauth.dat");
+			}
+		}
+
+		private class TokenSet
+		{
+			public string AccessToken { get; set; }
+			public string RefreshToken { get; set; }
+			public DateTime ExpiresAtUtc { get; set; }
+		}
+
+		private TokenSet _objCachedTokens;
+
+		/// <summary>
+		/// Whether a stored login already exists (does not guarantee it's still valid - the token may
+		/// have been revoked server-side).
+		/// </summary>
+		public bool HasStoredLogin()
+		{
+			return File.Exists(TokenFilePath);
+		}
+
+		/// <summary>
+		/// Runs the full interactive login flow: opens the system browser, listens on a loopback port
+		/// for the redirect, exchanges the code for tokens, and persists them.
+		/// </summary>
+		public async Task LoginAsync()
+		{
+			string strCodeVerifier = GenerateCodeVerifier();
+			string strCodeChallenge = GenerateCodeChallenge(strCodeVerifier);
+			string strState = Guid.NewGuid().ToString("N");
+
+			using (HttpListener objListener = new HttpListener())
+			{
+				int intPort = GetAvailableLoopbackPort();
+				string strRedirectUri = "http://127.0.0.1:" + intPort + "/callback/";
+				objListener.Prefixes.Add(strRedirectUri);
+				objListener.Start();
+
+				string strAuthorizeUrl = AuthorizationUrl
+					+ "?response_type=code"
+					+ "&client_id=" + Uri.EscapeDataString(ClientId)
+					+ "&redirect_uri=" + Uri.EscapeDataString(strRedirectUri)
+					+ "&scope=" + Uri.EscapeDataString(Scopes)
+					+ "&state=" + strState
+					+ "&code_challenge=" + strCodeChallenge
+					+ "&code_challenge_method=S256";
+
+				Process.Start(new ProcessStartInfo(strAuthorizeUrl) { UseShellExecute = true });
+
+				HttpListenerContext objContext = await objListener.GetContextAsync();
+				string strCode = objContext.Request.QueryString["code"];
+				string strReturnedState = objContext.Request.QueryString["state"];
+				string strError = objContext.Request.QueryString["error"];
+
+				string strResponseHtml = string.IsNullOrEmpty(strError) && strReturnedState == strState
+					? "<html><body>Login complete - you can close this tab and return to Chummer.</body></html>"
+					: "<html><body>Login failed - please return to Chummer and try again.</body></html>";
+				byte[] bytResponse = Encoding.UTF8.GetBytes(strResponseHtml);
+				objContext.Response.ContentLength64 = bytResponse.Length;
+				objContext.Response.OutputStream.Write(bytResponse, 0, bytResponse.Length);
+				objContext.Response.OutputStream.Close();
+				objListener.Stop();
+
+				if (!string.IsNullOrEmpty(strError))
+					throw new InvalidOperationException("RunnersPoint login failed: " + strError);
+				if (strReturnedState != strState)
+					throw new InvalidOperationException("RunnersPoint login failed: state mismatch (possible CSRF).");
+
+				await ExchangeCodeForTokensAsync(strCode, strCodeVerifier, strRedirectUri);
+			}
+		}
+
+		public void Logout()
+		{
+			_objCachedTokens = null;
+			if (File.Exists(TokenFilePath))
+				File.Delete(TokenFilePath);
+		}
+
+		/// <summary>
+		/// Returns a currently-valid access token, refreshing it first if it's expired. Throws if there's
+		/// no stored login or the refresh token has itself been revoked - callers should catch this and
+		/// prompt the user to LoginAsync() again.
+		/// </summary>
+		public async Task<string> GetAccessTokenAsync()
+		{
+			TokenSet objTokens = LoadTokens();
+			if (objTokens == null)
+				throw new InvalidOperationException("Not logged in to RunnersPoint.");
+
+			if (DateTime.UtcNow < objTokens.ExpiresAtUtc)
+				return objTokens.AccessToken;
+
+			await RefreshTokensAsync(objTokens);
+			return _objCachedTokens.AccessToken;
+		}
+
+		private async Task ExchangeCodeForTokensAsync(string strCode, string strCodeVerifier, string strRedirectUri)
+		{
+			Dictionary<string, string> objFormData = new Dictionary<string, string>
+			{
+				{ "grant_type", "authorization_code" },
+				{ "code", strCode },
+				{ "redirect_uri", strRedirectUri },
+				{ "client_id", ClientId },
+				{ "code_verifier", strCodeVerifier },
+			};
+			await RequestAndStoreTokensAsync(objFormData);
+		}
+
+		private async Task RefreshTokensAsync(TokenSet objExpiredTokens)
+		{
+			if (string.IsNullOrEmpty(objExpiredTokens.RefreshToken))
+				throw new InvalidOperationException("RunnersPoint session expired and cannot be refreshed - please log in again.");
+
+			Dictionary<string, string> objFormData = new Dictionary<string, string>
+			{
+				{ "grant_type", "refresh_token" },
+				{ "refresh_token", objExpiredTokens.RefreshToken },
+				{ "client_id", ClientId },
+			};
+			await RequestAndStoreTokensAsync(objFormData);
+		}
+
+		private async Task RequestAndStoreTokensAsync(Dictionary<string, string> objFormData)
+		{
+			using (HttpClient objHttpClient = new HttpClient())
+			using (FormUrlEncodedContent objContent = new FormUrlEncodedContent(objFormData))
+			{
+				HttpResponseMessage objResponse = await objHttpClient.PostAsync(TokenUrl, objContent);
+				string strBody = await objResponse.Content.ReadAsStringAsync();
+				if (!objResponse.IsSuccessStatusCode)
+					throw new InvalidOperationException("RunnersPoint token request failed (" + objResponse.StatusCode + "): " + strBody);
+
+				JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+				Dictionary<string, object> objJson = objSerializer.Deserialize<Dictionary<string, object>>(strBody);
+
+				TokenSet objTokens = new TokenSet();
+				objTokens.AccessToken = objJson["access_token"].ToString();
+				objTokens.RefreshToken = objJson.ContainsKey("refresh_token") ? objJson["refresh_token"].ToString() : (_objCachedTokens != null ? _objCachedTokens.RefreshToken : null);
+				int intExpiresIn = objJson.ContainsKey("expires_in") ? Convert.ToInt32(objJson["expires_in"]) : 3600;
+				// Refresh a little early so a request doesn't race an expiry that happens mid-flight.
+				objTokens.ExpiresAtUtc = DateTime.UtcNow.AddSeconds(intExpiresIn - 60);
+
+				SaveTokens(objTokens);
+				_objCachedTokens = objTokens;
+			}
+		}
+
+		private TokenSet LoadTokens()
+		{
+			if (_objCachedTokens != null)
+				return _objCachedTokens;
+
+			if (!File.Exists(TokenFilePath))
+				return null;
+
+			byte[] bytStored = File.ReadAllBytes(TokenFilePath);
+			byte[] bytJson;
+			if (IsWindows())
+			{
+				bytJson = ProtectedData.Unprotect(bytStored, null, DataProtectionScope.CurrentUser);
+			}
+			else
+			{
+				bytJson = bytStored;
+			}
+
+			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+			Dictionary<string, object> objJson = objSerializer.Deserialize<Dictionary<string, object>>(Encoding.UTF8.GetString(bytJson));
+
+			TokenSet objTokens = new TokenSet();
+			objTokens.AccessToken = objJson["accessToken"].ToString();
+			objTokens.RefreshToken = objJson.ContainsKey("refreshToken") ? objJson["refreshToken"].ToString() : null;
+			objTokens.ExpiresAtUtc = DateTime.Parse(objJson["expiresAtUtc"].ToString()).ToUniversalTime();
+
+			_objCachedTokens = objTokens;
+			return objTokens;
+		}
+
+		private void SaveTokens(TokenSet objTokens)
+		{
+			JavaScriptSerializer objSerializer = new JavaScriptSerializer();
+			string strJson = objSerializer.Serialize(new Dictionary<string, object>
+			{
+				{ "accessToken", objTokens.AccessToken },
+				{ "refreshToken", objTokens.RefreshToken },
+				{ "expiresAtUtc", objTokens.ExpiresAtUtc.ToString("o") },
+			});
+			byte[] bytJson = Encoding.UTF8.GetBytes(strJson);
+
+			byte[] bytToWrite;
+			if (IsWindows())
+			{
+				bytToWrite = ProtectedData.Protect(bytJson, null, DataProtectionScope.CurrentUser);
+			}
+			else
+			{
+				// No cross-platform secret store wired up yet - see class remarks. Flagged loudly rather
+				// than silently pretending this is as safe as the Windows path.
+				Trace.TraceWarning("RunnersPoint auth tokens are being stored in plain text on this platform - no secret store integration exists for Mono/Linux yet.");
+				bytToWrite = bytJson;
+			}
+
+			File.WriteAllBytes(TokenFilePath, bytToWrite);
+			if (!IsWindows())
+			{
+				try
+				{
+					// Best-effort lockdown; not a substitute for real secret storage.
+					Process.Start(new ProcessStartInfo("chmod", "600 \"" + TokenFilePath + "\"") { UseShellExecute = false, CreateNoWindow = true })?.WaitForExit();
+				}
+				catch
+				{
+				}
+			}
+		}
+
+		private static bool IsWindows()
+		{
+			return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+		}
+
+		private static string GenerateCodeVerifier()
+		{
+			byte[] bytRandom = new byte[32];
+			using (RandomNumberGenerator objRng = RandomNumberGenerator.Create())
+				objRng.GetBytes(bytRandom);
+			return Base64UrlEncode(bytRandom);
+		}
+
+		private static string GenerateCodeChallenge(string strCodeVerifier)
+		{
+			using (SHA256 objSha256 = SHA256.Create())
+			{
+				byte[] bytHash = objSha256.ComputeHash(Encoding.ASCII.GetBytes(strCodeVerifier));
+				return Base64UrlEncode(bytHash);
+			}
+		}
+
+		private static string Base64UrlEncode(byte[] bytInput)
+		{
+			return Convert.ToBase64String(bytInput).Replace('+', '-').Replace('/', '_').TrimEnd('=');
+		}
+
+		private static int GetAvailableLoopbackPort()
+		{
+			System.Net.Sockets.TcpListener objSocketListener = new System.Net.Sockets.TcpListener(IPAddress.Loopback, 0);
+			objSocketListener.Start();
+			int intPort = ((IPEndPoint)objSocketListener.LocalEndpoint).Port;
+			objSocketListener.Stop();
+			return intPort;
+		}
+	}
+}

--- a/Chummer/code/clsRunnersPointAuth.cs
+++ b/Chummer/code/clsRunnersPointAuth.cs
@@ -13,9 +13,17 @@ using System.Web.Script.Serialization;
 namespace Chummer
 {
 	/// <summary>
-	/// OAuth2 Authorization Code + PKCE flow for the RunnersPoint API, plus token persistence. Chummer
-	/// is distributed as a public client (no embeddable secret), so this uses PKCE with a loopback
-	/// redirect and the system browser - the standard pattern for native/desktop OAuth clients.
+	/// Authentication against the RunnersPoint API. Supports two mechanisms:
+	///
+	/// - apiToken: a long-lived bearer token (`rp_...`, minted server-side via `POST /api/v1/tokens`
+	///   while logged into the RunnersPoint website, up to a 90-day expiry) pasted into Chummer via
+	///   SetApiToken. This is what the real RunnersPoint server actually implements today - its
+	///   security firewall only wires up a custom ApiTokenAuthenticator, not an OAuth2 authorization
+	///   server - so this is the path that works right now.
+	/// - OAuth2 Authorization Code + PKCE via LoginAsync/the system browser: kept for if/when
+	///   RunnersPoint stands up a real authorization server. Chummer is a public client (no embeddable
+	///   secret), so PKCE with a loopback redirect is the standard pattern for that case. Untested
+	///   against a live server since none exists yet.
 	///
 	/// Token storage: DPAPI-protected on Windows (CurrentUser scope, so only the OS account that logged
 	/// in can decrypt it). On non-Windows platforms (Mono/Linux) there is currently no equivalent secret
@@ -47,6 +55,10 @@ namespace Chummer
 			public string AccessToken { get; set; }
 			public string RefreshToken { get; set; }
 			public DateTime ExpiresAtUtc { get; set; }
+			// True for a pasted apiToken (SetApiToken) - these have no refresh token and are used as-is
+			// until the server itself rejects them (expired or revoked), rather than tracked against a
+			// client-side expiry.
+			public bool IsApiToken { get; set; }
 		}
 
 		private TokenSet _objCachedTokens;
@@ -119,9 +131,33 @@ namespace Chummer
 		}
 
 		/// <summary>
-		/// Returns a currently-valid access token, refreshing it first if it's expired. Throws if there's
-		/// no stored login or the refresh token has itself been revoked - callers should catch this and
-		/// prompt the user to LoginAsync() again.
+		/// Stores a pre-minted RunnersPoint apiToken (format "rp_...", from POST /api/v1/tokens on the
+		/// website) as the credential to use, replacing any existing OAuth or apiToken login. There is no
+		/// refresh for this path - once the server rejects it (expired or revoked), the caller needs a
+		/// fresh token pasted in again.
+		/// </summary>
+		public void SetApiToken(string strToken)
+		{
+			strToken = (strToken ?? "").Trim();
+			if (!strToken.StartsWith("rp_", StringComparison.Ordinal) || strToken.Length < 35)
+				throw new ArgumentException("That doesn't look like a RunnersPoint API token - it should start with \"rp_\".");
+
+			TokenSet objTokens = new TokenSet
+			{
+				AccessToken = strToken,
+				RefreshToken = null,
+				IsApiToken = true,
+				ExpiresAtUtc = DateTime.MaxValue,
+			};
+			SaveTokens(objTokens);
+			_objCachedTokens = objTokens;
+		}
+
+		/// <summary>
+		/// Returns a currently-valid access token. For a pasted apiToken, that's just the stored token -
+		/// there's no client-tracked expiry or refresh for it. For an OAuth login, refreshes first if
+		/// expired. Throws if there's no stored login or the refresh token has itself been revoked -
+		/// callers should catch this and prompt the user to log in again.
 		/// </summary>
 		public async Task<string> GetAccessTokenAsync()
 		{
@@ -129,7 +165,7 @@ namespace Chummer
 			if (objTokens == null)
 				throw new InvalidOperationException("Not logged in to RunnersPoint.");
 
-			if (DateTime.UtcNow < objTokens.ExpiresAtUtc)
+			if (objTokens.IsApiToken || DateTime.UtcNow < objTokens.ExpiresAtUtc)
 				return objTokens.AccessToken;
 
 			await RefreshTokensAsync(objTokens);
@@ -214,6 +250,7 @@ namespace Chummer
 			objTokens.AccessToken = objJson["accessToken"].ToString();
 			objTokens.RefreshToken = objJson.ContainsKey("refreshToken") ? objJson["refreshToken"].ToString() : null;
 			objTokens.ExpiresAtUtc = DateTime.Parse(objJson["expiresAtUtc"].ToString()).ToUniversalTime();
+			objTokens.IsApiToken = objJson.ContainsKey("isApiToken") && Convert.ToBoolean(objJson["isApiToken"]);
 
 			_objCachedTokens = objTokens;
 			return objTokens;
@@ -227,6 +264,7 @@ namespace Chummer
 				{ "accessToken", objTokens.AccessToken },
 				{ "refreshToken", objTokens.RefreshToken },
 				{ "expiresAtUtc", objTokens.ExpiresAtUtc.ToString("o") },
+				{ "isApiToken", objTokens.IsApiToken },
 			});
 			byte[] bytJson = Encoding.UTF8.GetBytes(strJson);
 

--- a/Chummer/code/frmCareer.cs
+++ b/Chummer/code/frmCareer.cs
@@ -21,6 +21,14 @@ namespace Chummer
 		private Character _objCharacter;
 		private MainController _objController;
 
+		/// <summary>
+		/// The Character open in this window.
+		/// </summary>
+		public Character CharacterObject
+		{
+			get { return _objCharacter; }
+		}
+
 		private CharacterOptions _objOptions;
 		private CommonFunctions _objFunctions;
 		private bool _blnSkipRefresh = false;
@@ -23554,6 +23562,9 @@ namespace Chummer
 			if (saveFileDialog.ShowDialog(this) == DialogResult.OK)
 			{
 				string strFileName = saveFileDialog.FileName;
+				// A Save As copy is an independent character - it should get its own cloud document
+				// on next push, not silently push new revisions onto the original's document.
+				_objCharacter.CloudDocumentId = "";
 				_objCharacter.FileName = strFileName;
 				_objCharacter.Save();
 				_blnIsDirty = false;

--- a/Chummer/code/frmCloudDocuments.Designer.cs
+++ b/Chummer/code/frmCloudDocuments.Designer.cs
@@ -35,6 +35,7 @@ namespace Chummer
 			this.cmdDownload = new System.Windows.Forms.Button();
 			this.cmdArchive = new System.Windows.Forms.Button();
 			this.cmdPushShared = new System.Windows.Forms.Button();
+			this.cmdEditMetadata = new System.Windows.Forms.Button();
 			this.lblStatus = new System.Windows.Forms.Label();
 #if DEBUG
 			this.cmdDebugInfo = new System.Windows.Forms.Button();
@@ -246,6 +247,17 @@ namespace Chummer
 			this.cmdPushShared.Visible = false;
 			this.cmdPushShared.Click += new System.EventHandler(this.cmdPushShared_Click);
 			//
+			// cmdEditMetadata
+			//
+			this.cmdEditMetadata.Location = new System.Drawing.Point(441, 458);
+			this.cmdEditMetadata.Name = "cmdEditMetadata";
+			this.cmdEditMetadata.Size = new System.Drawing.Size(115, 27);
+			this.cmdEditMetadata.TabIndex = 16;
+			this.cmdEditMetadata.Tag = "Button_Cloud_EditMetadata";
+			this.cmdEditMetadata.Text = "Edit Metadata...";
+			this.cmdEditMetadata.UseVisualStyleBackColor = true;
+			this.cmdEditMetadata.Click += new System.EventHandler(this.cmdEditMetadata_Click);
+			//
 #if DEBUG
 			// cmdDebugInfo
 			//
@@ -264,7 +276,7 @@ namespace Chummer
 			this.lblStatus.Location = new System.Drawing.Point(12, 494);
 			this.lblStatus.Name = "lblStatus";
 			this.lblStatus.Size = new System.Drawing.Size(38, 13);
-			this.lblStatus.TabIndex = 16;
+			this.lblStatus.TabIndex = 18;
 			this.lblStatus.Text = "";
 			this.lblStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			//
@@ -277,6 +289,7 @@ namespace Chummer
 			this.Controls.Add(this.cmdDebugInfo);
 #endif
 			this.Controls.Add(this.lblStatus);
+			this.Controls.Add(this.cmdEditMetadata);
 			this.Controls.Add(this.cmdPushShared);
 			this.Controls.Add(this.cmdArchive);
 			this.Controls.Add(this.cmdDownload);
@@ -322,6 +335,7 @@ namespace Chummer
 		private System.Windows.Forms.Button cmdDownload;
 		private System.Windows.Forms.Button cmdArchive;
 		private System.Windows.Forms.Button cmdPushShared;
+		private System.Windows.Forms.Button cmdEditMetadata;
 		private System.Windows.Forms.Label lblStatus;
 #if DEBUG
 		private System.Windows.Forms.Button cmdDebugInfo;

--- a/Chummer/code/frmCloudDocuments.Designer.cs
+++ b/Chummer/code/frmCloudDocuments.Designer.cs
@@ -17,9 +17,12 @@ namespace Chummer
 		{
 			this.rdoMyDocuments = new System.Windows.Forms.RadioButton();
 			this.rdoSharedWithMe = new System.Windows.Forms.RadioButton();
+			this.rdoAuthApiToken = new System.Windows.Forms.RadioButton();
+			this.rdoAuthOAuth = new System.Windows.Forms.RadioButton();
 			this.lblApiToken = new System.Windows.Forms.Label();
 			this.txtApiToken = new System.Windows.Forms.TextBox();
 			this.cmdUseApiToken = new System.Windows.Forms.Button();
+			this.lblConnectionState = new System.Windows.Forms.Label();
 			this.lstDocuments = new System.Windows.Forms.ListView();
 			this.colName = new System.Windows.Forms.ColumnHeader();
 			this.colState = new System.Windows.Forms.ColumnHeader();
@@ -58,34 +61,79 @@ namespace Chummer
 			this.rdoSharedWithMe.UseVisualStyleBackColor = true;
 			this.rdoSharedWithMe.CheckedChanged += new System.EventHandler(this.rdoDocumentMode_CheckedChanged);
 			//
+			// rdoAuthApiToken
+			//
+			this.rdoAuthApiToken.Checked = true;
+			this.rdoAuthApiToken.Location = new System.Drawing.Point(12, 38);
+			this.rdoAuthApiToken.Name = "rdoAuthApiToken";
+			this.rdoAuthApiToken.Size = new System.Drawing.Size(140, 20);
+			this.rdoAuthApiToken.TabIndex = 2;
+			this.rdoAuthApiToken.TabStop = true;
+			this.rdoAuthApiToken.Tag = "Radio_Cloud_AuthApiToken";
+			this.rdoAuthApiToken.Text = "Use API Token";
+			this.rdoAuthApiToken.UseVisualStyleBackColor = true;
+			this.rdoAuthApiToken.CheckedChanged += new System.EventHandler(this.rdoAuthMode_CheckedChanged);
+			//
+			// rdoAuthOAuth
+			//
+			this.rdoAuthOAuth.Location = new System.Drawing.Point(158, 38);
+			this.rdoAuthOAuth.Name = "rdoAuthOAuth";
+			this.rdoAuthOAuth.Size = new System.Drawing.Size(160, 20);
+			this.rdoAuthOAuth.TabIndex = 3;
+			this.rdoAuthOAuth.Tag = "Radio_Cloud_AuthOAuth";
+			this.rdoAuthOAuth.Text = "Use OAuth Login";
+			this.rdoAuthOAuth.UseVisualStyleBackColor = true;
+			this.rdoAuthOAuth.CheckedChanged += new System.EventHandler(this.rdoAuthMode_CheckedChanged);
+			//
 			// lblApiToken
 			//
 			this.lblApiToken.AutoSize = true;
-			this.lblApiToken.Location = new System.Drawing.Point(12, 41);
+			this.lblApiToken.Location = new System.Drawing.Point(12, 67);
 			this.lblApiToken.Name = "lblApiToken";
 			this.lblApiToken.Size = new System.Drawing.Size(60, 13);
-			this.lblApiToken.TabIndex = 2;
+			this.lblApiToken.TabIndex = 4;
 			this.lblApiToken.Tag = "Label_Cloud_ApiToken";
 			this.lblApiToken.Text = "API Token:";
 			//
 			// txtApiToken
 			//
-			this.txtApiToken.Location = new System.Drawing.Point(80, 38);
+			this.txtApiToken.Location = new System.Drawing.Point(80, 64);
 			this.txtApiToken.Name = "txtApiToken";
 			this.txtApiToken.Size = new System.Drawing.Size(300, 20);
-			this.txtApiToken.TabIndex = 3;
+			this.txtApiToken.TabIndex = 5;
 			this.txtApiToken.UseSystemPasswordChar = true;
 			//
 			// cmdUseApiToken
 			//
-			this.cmdUseApiToken.Location = new System.Drawing.Point(386, 36);
+			this.cmdUseApiToken.Location = new System.Drawing.Point(386, 62);
 			this.cmdUseApiToken.Name = "cmdUseApiToken";
 			this.cmdUseApiToken.Size = new System.Drawing.Size(90, 23);
-			this.cmdUseApiToken.TabIndex = 4;
+			this.cmdUseApiToken.TabIndex = 6;
 			this.cmdUseApiToken.Tag = "Button_Cloud_UseApiToken";
 			this.cmdUseApiToken.Text = "Use Token";
 			this.cmdUseApiToken.UseVisualStyleBackColor = true;
 			this.cmdUseApiToken.Click += new System.EventHandler(this.cmdUseApiToken_Click);
+			//
+			// cmdLogin
+			//
+			this.cmdLogin.Location = new System.Drawing.Point(12, 62);
+			this.cmdLogin.Name = "cmdLogin";
+			this.cmdLogin.Size = new System.Drawing.Size(90, 23);
+			this.cmdLogin.TabIndex = 7;
+			this.cmdLogin.Tag = "Button_Cloud_Login";
+			this.cmdLogin.Text = "Log In";
+			this.cmdLogin.Visible = false;
+			this.cmdLogin.UseVisualStyleBackColor = true;
+			this.cmdLogin.Click += new System.EventHandler(this.cmdLogin_Click);
+			//
+			// lblConnectionState
+			//
+			this.lblConnectionState.AutoSize = true;
+			this.lblConnectionState.Location = new System.Drawing.Point(12, 92);
+			this.lblConnectionState.Name = "lblConnectionState";
+			this.lblConnectionState.Size = new System.Drawing.Size(90, 13);
+			this.lblConnectionState.TabIndex = 8;
+			this.lblConnectionState.Text = "";
 			//
 			// lstDocuments
 			//
@@ -98,10 +146,10 @@ namespace Chummer
 			this.lstDocuments.FullRowSelect = true;
 			this.lstDocuments.MultiSelect = false;
 			this.lstDocuments.HideSelection = false;
-			this.lstDocuments.Location = new System.Drawing.Point(12, 64);
+			this.lstDocuments.Location = new System.Drawing.Point(12, 116);
 			this.lstDocuments.Name = "lstDocuments";
 			this.lstDocuments.Size = new System.Drawing.Size(560, 300);
-			this.lstDocuments.TabIndex = 5;
+			this.lstDocuments.TabIndex = 9;
 			this.lstDocuments.SelectedIndexChanged += new System.EventHandler(this.lstDocuments_SelectedIndexChanged);
 			this.lstDocuments.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
 				| System.Windows.Forms.AnchorStyles.Left)
@@ -127,23 +175,12 @@ namespace Chummer
 			this.colShare.Text = "Share";
 			this.colShare.Width = 100;
 			//
-			// cmdLogin
-			//
-			this.cmdLogin.Location = new System.Drawing.Point(12, 372);
-			this.cmdLogin.Name = "cmdLogin";
-			this.cmdLogin.Size = new System.Drawing.Size(90, 27);
-			this.cmdLogin.TabIndex = 6;
-			this.cmdLogin.Tag = "Button_Cloud_Login";
-			this.cmdLogin.Text = "Log In";
-			this.cmdLogin.UseVisualStyleBackColor = true;
-			this.cmdLogin.Click += new System.EventHandler(this.cmdLogin_Click);
-			//
 			// cmdLogout
 			//
-			this.cmdLogout.Location = new System.Drawing.Point(108, 372);
+			this.cmdLogout.Location = new System.Drawing.Point(12, 424);
 			this.cmdLogout.Name = "cmdLogout";
 			this.cmdLogout.Size = new System.Drawing.Size(90, 27);
-			this.cmdLogout.TabIndex = 7;
+			this.cmdLogout.TabIndex = 10;
 			this.cmdLogout.Tag = "Button_Cloud_Logout";
 			this.cmdLogout.Text = "Log Out";
 			this.cmdLogout.UseVisualStyleBackColor = true;
@@ -151,10 +188,10 @@ namespace Chummer
 			//
 			// cmdRefresh
 			//
-			this.cmdRefresh.Location = new System.Drawing.Point(204, 372);
+			this.cmdRefresh.Location = new System.Drawing.Point(108, 424);
 			this.cmdRefresh.Name = "cmdRefresh";
 			this.cmdRefresh.Size = new System.Drawing.Size(90, 27);
-			this.cmdRefresh.TabIndex = 8;
+			this.cmdRefresh.TabIndex = 11;
 			this.cmdRefresh.Tag = "Button_Cloud_Refresh";
 			this.cmdRefresh.Text = "Refresh";
 			this.cmdRefresh.UseVisualStyleBackColor = true;
@@ -162,10 +199,10 @@ namespace Chummer
 			//
 			// cmdPushCurrent
 			//
-			this.cmdPushCurrent.Location = new System.Drawing.Point(300, 372);
+			this.cmdPushCurrent.Location = new System.Drawing.Point(204, 424);
 			this.cmdPushCurrent.Name = "cmdPushCurrent";
 			this.cmdPushCurrent.Size = new System.Drawing.Size(150, 27);
-			this.cmdPushCurrent.TabIndex = 9;
+			this.cmdPushCurrent.TabIndex = 12;
 			this.cmdPushCurrent.Tag = "Button_Cloud_PushCurrent";
 			this.cmdPushCurrent.Text = "Push Current Character";
 			this.cmdPushCurrent.UseVisualStyleBackColor = true;
@@ -173,10 +210,10 @@ namespace Chummer
 			//
 			// cmdDownload
 			//
-			this.cmdDownload.Location = new System.Drawing.Point(456, 372);
+			this.cmdDownload.Location = new System.Drawing.Point(456, 424);
 			this.cmdDownload.Name = "cmdDownload";
 			this.cmdDownload.Size = new System.Drawing.Size(115, 27);
-			this.cmdDownload.TabIndex = 10;
+			this.cmdDownload.TabIndex = 13;
 			this.cmdDownload.Tag = "Button_Cloud_Download";
 			this.cmdDownload.Text = "Download Selected";
 			this.cmdDownload.UseVisualStyleBackColor = true;
@@ -184,10 +221,10 @@ namespace Chummer
 			//
 			// cmdArchive
 			//
-			this.cmdArchive.Location = new System.Drawing.Point(12, 406);
+			this.cmdArchive.Location = new System.Drawing.Point(12, 458);
 			this.cmdArchive.Name = "cmdArchive";
 			this.cmdArchive.Size = new System.Drawing.Size(115, 27);
-			this.cmdArchive.TabIndex = 11;
+			this.cmdArchive.TabIndex = 14;
 			this.cmdArchive.Tag = "Button_Cloud_Archive";
 			this.cmdArchive.Text = "Archive Selected";
 			this.cmdArchive.UseVisualStyleBackColor = true;
@@ -195,10 +232,10 @@ namespace Chummer
 			//
 			// cmdPushShared
 			//
-			this.cmdPushShared.Location = new System.Drawing.Point(133, 406);
+			this.cmdPushShared.Location = new System.Drawing.Point(133, 458);
 			this.cmdPushShared.Name = "cmdPushShared";
 			this.cmdPushShared.Size = new System.Drawing.Size(180, 27);
-			this.cmdPushShared.TabIndex = 12;
+			this.cmdPushShared.TabIndex = 15;
 			this.cmdPushShared.Tag = "Button_Cloud_PushShared";
 			this.cmdPushShared.Text = "Push Update to Selected";
 			this.cmdPushShared.UseVisualStyleBackColor = true;
@@ -208,10 +245,10 @@ namespace Chummer
 			// lblStatus
 			//
 			this.lblStatus.AutoSize = true;
-			this.lblStatus.Location = new System.Drawing.Point(12, 442);
+			this.lblStatus.Location = new System.Drawing.Point(12, 494);
 			this.lblStatus.Name = "lblStatus";
 			this.lblStatus.Size = new System.Drawing.Size(38, 13);
-			this.lblStatus.TabIndex = 13;
+			this.lblStatus.TabIndex = 16;
 			this.lblStatus.Text = "";
 			this.lblStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			//
@@ -219,7 +256,7 @@ namespace Chummer
 			//
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(584, 473);
+			this.ClientSize = new System.Drawing.Size(584, 525);
 			this.Controls.Add(this.lblStatus);
 			this.Controls.Add(this.cmdPushShared);
 			this.Controls.Add(this.cmdArchive);
@@ -227,14 +264,17 @@ namespace Chummer
 			this.Controls.Add(this.cmdPushCurrent);
 			this.Controls.Add(this.cmdRefresh);
 			this.Controls.Add(this.cmdLogout);
-			this.Controls.Add(this.cmdLogin);
 			this.Controls.Add(this.lstDocuments);
+			this.Controls.Add(this.lblConnectionState);
+			this.Controls.Add(this.cmdLogin);
 			this.Controls.Add(this.cmdUseApiToken);
 			this.Controls.Add(this.txtApiToken);
 			this.Controls.Add(this.lblApiToken);
+			this.Controls.Add(this.rdoAuthOAuth);
+			this.Controls.Add(this.rdoAuthApiToken);
 			this.Controls.Add(this.rdoSharedWithMe);
 			this.Controls.Add(this.rdoMyDocuments);
-			this.MinimumSize = new System.Drawing.Size(500, 402);
+			this.MinimumSize = new System.Drawing.Size(500, 454);
 			this.Name = "frmCloudDocuments";
 			this.Tag = "Title_CloudDocuments";
 			this.Text = "Cloud Documents";
@@ -245,9 +285,12 @@ namespace Chummer
 
 		private System.Windows.Forms.RadioButton rdoMyDocuments;
 		private System.Windows.Forms.RadioButton rdoSharedWithMe;
+		private System.Windows.Forms.RadioButton rdoAuthApiToken;
+		private System.Windows.Forms.RadioButton rdoAuthOAuth;
 		private System.Windows.Forms.Label lblApiToken;
 		private System.Windows.Forms.TextBox txtApiToken;
 		private System.Windows.Forms.Button cmdUseApiToken;
+		private System.Windows.Forms.Label lblConnectionState;
 		private System.Windows.Forms.ListView lstDocuments;
 		private System.Windows.Forms.ColumnHeader colName;
 		private System.Windows.Forms.ColumnHeader colState;

--- a/Chummer/code/frmCloudDocuments.Designer.cs
+++ b/Chummer/code/frmCloudDocuments.Designer.cs
@@ -36,6 +36,9 @@ namespace Chummer
 			this.cmdArchive = new System.Windows.Forms.Button();
 			this.cmdPushShared = new System.Windows.Forms.Button();
 			this.lblStatus = new System.Windows.Forms.Label();
+#if DEBUG
+			this.cmdDebugInfo = new System.Windows.Forms.Button();
+#endif
 			this.SuspendLayout();
 			//
 			// rdoMyDocuments
@@ -243,6 +246,18 @@ namespace Chummer
 			this.cmdPushShared.Visible = false;
 			this.cmdPushShared.Click += new System.EventHandler(this.cmdPushShared_Click);
 			//
+#if DEBUG
+			// cmdDebugInfo
+			//
+			this.cmdDebugInfo.Location = new System.Drawing.Point(320, 458);
+			this.cmdDebugInfo.Name = "cmdDebugInfo";
+			this.cmdDebugInfo.Size = new System.Drawing.Size(115, 27);
+			this.cmdDebugInfo.TabIndex = 17;
+			this.cmdDebugInfo.Text = "Debug Info...";
+			this.cmdDebugInfo.UseVisualStyleBackColor = true;
+			this.cmdDebugInfo.Click += new System.EventHandler(this.cmdDebugInfo_Click);
+			//
+#endif
 			// lblStatus
 			//
 			this.lblStatus.AutoSize = true;
@@ -258,6 +273,9 @@ namespace Chummer
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.ClientSize = new System.Drawing.Size(584, 525);
+#if DEBUG
+			this.Controls.Add(this.cmdDebugInfo);
+#endif
 			this.Controls.Add(this.lblStatus);
 			this.Controls.Add(this.cmdPushShared);
 			this.Controls.Add(this.cmdArchive);
@@ -305,5 +323,8 @@ namespace Chummer
 		private System.Windows.Forms.Button cmdArchive;
 		private System.Windows.Forms.Button cmdPushShared;
 		private System.Windows.Forms.Label lblStatus;
+#if DEBUG
+		private System.Windows.Forms.Button cmdDebugInfo;
+#endif
 	}
 }

--- a/Chummer/code/frmCloudDocuments.Designer.cs
+++ b/Chummer/code/frmCloudDocuments.Designer.cs
@@ -1,0 +1,174 @@
+namespace Chummer
+{
+	partial class frmCloudDocuments
+	{
+		private System.ComponentModel.IContainer components = null;
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		private void InitializeComponent()
+		{
+			this.lstDocuments = new System.Windows.Forms.ListView();
+			this.colName = new System.Windows.Forms.ColumnHeader();
+			this.colState = new System.Windows.Forms.ColumnHeader();
+			this.colUpdated = new System.Windows.Forms.ColumnHeader();
+			this.cmdLogin = new System.Windows.Forms.Button();
+			this.cmdLogout = new System.Windows.Forms.Button();
+			this.cmdRefresh = new System.Windows.Forms.Button();
+			this.cmdPushCurrent = new System.Windows.Forms.Button();
+			this.cmdDownload = new System.Windows.Forms.Button();
+			this.cmdArchive = new System.Windows.Forms.Button();
+			this.lblStatus = new System.Windows.Forms.Label();
+			this.SuspendLayout();
+			//
+			// lstDocuments
+			//
+			this.lstDocuments.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
+				this.colName,
+				this.colState,
+				this.colUpdated});
+			this.lstDocuments.View = System.Windows.Forms.View.Details;
+			this.lstDocuments.FullRowSelect = true;
+			this.lstDocuments.MultiSelect = false;
+			this.lstDocuments.HideSelection = false;
+			this.lstDocuments.Location = new System.Drawing.Point(12, 12);
+			this.lstDocuments.Name = "lstDocuments";
+			this.lstDocuments.Size = new System.Drawing.Size(560, 300);
+			this.lstDocuments.TabIndex = 0;
+			this.lstDocuments.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+				| System.Windows.Forms.AnchorStyles.Left)
+				| System.Windows.Forms.AnchorStyles.Right)));
+			//
+			// colName
+			//
+			this.colName.Text = "Name";
+			this.colName.Width = 280;
+			//
+			// colState
+			//
+			this.colState.Text = "Validation State";
+			this.colState.Width = 120;
+			//
+			// colUpdated
+			//
+			this.colUpdated.Text = "Updated";
+			this.colUpdated.Width = 140;
+			//
+			// cmdLogin
+			//
+			this.cmdLogin.Location = new System.Drawing.Point(12, 320);
+			this.cmdLogin.Name = "cmdLogin";
+			this.cmdLogin.Size = new System.Drawing.Size(90, 27);
+			this.cmdLogin.TabIndex = 1;
+			this.cmdLogin.Tag = "Button_Cloud_Login";
+			this.cmdLogin.Text = "Log In";
+			this.cmdLogin.UseVisualStyleBackColor = true;
+			this.cmdLogin.Click += new System.EventHandler(this.cmdLogin_Click);
+			//
+			// cmdLogout
+			//
+			this.cmdLogout.Location = new System.Drawing.Point(108, 320);
+			this.cmdLogout.Name = "cmdLogout";
+			this.cmdLogout.Size = new System.Drawing.Size(90, 27);
+			this.cmdLogout.TabIndex = 2;
+			this.cmdLogout.Tag = "Button_Cloud_Logout";
+			this.cmdLogout.Text = "Log Out";
+			this.cmdLogout.UseVisualStyleBackColor = true;
+			this.cmdLogout.Click += new System.EventHandler(this.cmdLogout_Click);
+			//
+			// cmdRefresh
+			//
+			this.cmdRefresh.Location = new System.Drawing.Point(204, 320);
+			this.cmdRefresh.Name = "cmdRefresh";
+			this.cmdRefresh.Size = new System.Drawing.Size(90, 27);
+			this.cmdRefresh.TabIndex = 3;
+			this.cmdRefresh.Tag = "Button_Cloud_Refresh";
+			this.cmdRefresh.Text = "Refresh";
+			this.cmdRefresh.UseVisualStyleBackColor = true;
+			this.cmdRefresh.Click += new System.EventHandler(this.cmdRefresh_Click);
+			//
+			// cmdPushCurrent
+			//
+			this.cmdPushCurrent.Location = new System.Drawing.Point(300, 320);
+			this.cmdPushCurrent.Name = "cmdPushCurrent";
+			this.cmdPushCurrent.Size = new System.Drawing.Size(150, 27);
+			this.cmdPushCurrent.TabIndex = 4;
+			this.cmdPushCurrent.Tag = "Button_Cloud_PushCurrent";
+			this.cmdPushCurrent.Text = "Push Current Character";
+			this.cmdPushCurrent.UseVisualStyleBackColor = true;
+			this.cmdPushCurrent.Click += new System.EventHandler(this.cmdPushCurrent_Click);
+			//
+			// cmdDownload
+			//
+			this.cmdDownload.Location = new System.Drawing.Point(456, 320);
+			this.cmdDownload.Name = "cmdDownload";
+			this.cmdDownload.Size = new System.Drawing.Size(115, 27);
+			this.cmdDownload.TabIndex = 5;
+			this.cmdDownload.Tag = "Button_Cloud_Download";
+			this.cmdDownload.Text = "Download Selected";
+			this.cmdDownload.UseVisualStyleBackColor = true;
+			this.cmdDownload.Click += new System.EventHandler(this.cmdDownload_Click);
+			//
+			// cmdArchive
+			//
+			this.cmdArchive.Location = new System.Drawing.Point(12, 354);
+			this.cmdArchive.Name = "cmdArchive";
+			this.cmdArchive.Size = new System.Drawing.Size(115, 27);
+			this.cmdArchive.TabIndex = 6;
+			this.cmdArchive.Tag = "Button_Cloud_Archive";
+			this.cmdArchive.Text = "Archive Selected";
+			this.cmdArchive.UseVisualStyleBackColor = true;
+			this.cmdArchive.Click += new System.EventHandler(this.cmdArchive_Click);
+			//
+			// lblStatus
+			//
+			this.lblStatus.AutoSize = true;
+			this.lblStatus.Location = new System.Drawing.Point(12, 390);
+			this.lblStatus.Name = "lblStatus";
+			this.lblStatus.Size = new System.Drawing.Size(38, 13);
+			this.lblStatus.TabIndex = 7;
+			this.lblStatus.Text = "";
+			this.lblStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+			//
+			// frmCloudDocuments
+			//
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(584, 421);
+			this.Controls.Add(this.lblStatus);
+			this.Controls.Add(this.cmdArchive);
+			this.Controls.Add(this.cmdDownload);
+			this.Controls.Add(this.cmdPushCurrent);
+			this.Controls.Add(this.cmdRefresh);
+			this.Controls.Add(this.cmdLogout);
+			this.Controls.Add(this.cmdLogin);
+			this.Controls.Add(this.lstDocuments);
+			this.MinimumSize = new System.Drawing.Size(500, 350);
+			this.Name = "frmCloudDocuments";
+			this.Tag = "Title_CloudDocuments";
+			this.Text = "Cloud Documents";
+			this.Load += new System.EventHandler(this.frmCloudDocuments_Load);
+			this.ResumeLayout(false);
+			this.PerformLayout();
+		}
+
+		private System.Windows.Forms.ListView lstDocuments;
+		private System.Windows.Forms.ColumnHeader colName;
+		private System.Windows.Forms.ColumnHeader colState;
+		private System.Windows.Forms.ColumnHeader colUpdated;
+		private System.Windows.Forms.Button cmdLogin;
+		private System.Windows.Forms.Button cmdLogout;
+		private System.Windows.Forms.Button cmdRefresh;
+		private System.Windows.Forms.Button cmdPushCurrent;
+		private System.Windows.Forms.Button cmdDownload;
+		private System.Windows.Forms.Button cmdArchive;
+		private System.Windows.Forms.Label lblStatus;
+	}
+}

--- a/Chummer/code/frmCloudDocuments.Designer.cs
+++ b/Chummer/code/frmCloudDocuments.Designer.cs
@@ -15,33 +15,62 @@ namespace Chummer
 
 		private void InitializeComponent()
 		{
+			this.rdoMyDocuments = new System.Windows.Forms.RadioButton();
+			this.rdoSharedWithMe = new System.Windows.Forms.RadioButton();
 			this.lstDocuments = new System.Windows.Forms.ListView();
 			this.colName = new System.Windows.Forms.ColumnHeader();
 			this.colState = new System.Windows.Forms.ColumnHeader();
 			this.colUpdated = new System.Windows.Forms.ColumnHeader();
+			this.colShare = new System.Windows.Forms.ColumnHeader();
 			this.cmdLogin = new System.Windows.Forms.Button();
 			this.cmdLogout = new System.Windows.Forms.Button();
 			this.cmdRefresh = new System.Windows.Forms.Button();
 			this.cmdPushCurrent = new System.Windows.Forms.Button();
 			this.cmdDownload = new System.Windows.Forms.Button();
 			this.cmdArchive = new System.Windows.Forms.Button();
+			this.cmdPushShared = new System.Windows.Forms.Button();
 			this.lblStatus = new System.Windows.Forms.Label();
 			this.SuspendLayout();
+			//
+			// rdoMyDocuments
+			//
+			this.rdoMyDocuments.Location = new System.Drawing.Point(12, 12);
+			this.rdoMyDocuments.Name = "rdoMyDocuments";
+			this.rdoMyDocuments.Size = new System.Drawing.Size(140, 20);
+			this.rdoMyDocuments.TabIndex = 0;
+			this.rdoMyDocuments.Tag = "Radio_Cloud_MyDocuments";
+			this.rdoMyDocuments.Text = "My Documents";
+			this.rdoMyDocuments.Checked = true;
+			this.rdoMyDocuments.UseVisualStyleBackColor = true;
+			this.rdoMyDocuments.CheckedChanged += new System.EventHandler(this.rdoDocumentMode_CheckedChanged);
+			//
+			// rdoSharedWithMe
+			//
+			this.rdoSharedWithMe.Location = new System.Drawing.Point(158, 12);
+			this.rdoSharedWithMe.Name = "rdoSharedWithMe";
+			this.rdoSharedWithMe.Size = new System.Drawing.Size(160, 20);
+			this.rdoSharedWithMe.TabIndex = 1;
+			this.rdoSharedWithMe.Tag = "Radio_Cloud_SharedWithMe";
+			this.rdoSharedWithMe.Text = "Shared With Me";
+			this.rdoSharedWithMe.UseVisualStyleBackColor = true;
+			this.rdoSharedWithMe.CheckedChanged += new System.EventHandler(this.rdoDocumentMode_CheckedChanged);
 			//
 			// lstDocuments
 			//
 			this.lstDocuments.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
 				this.colName,
 				this.colState,
-				this.colUpdated});
+				this.colUpdated,
+				this.colShare});
 			this.lstDocuments.View = System.Windows.Forms.View.Details;
 			this.lstDocuments.FullRowSelect = true;
 			this.lstDocuments.MultiSelect = false;
 			this.lstDocuments.HideSelection = false;
-			this.lstDocuments.Location = new System.Drawing.Point(12, 12);
+			this.lstDocuments.Location = new System.Drawing.Point(12, 38);
 			this.lstDocuments.Name = "lstDocuments";
 			this.lstDocuments.Size = new System.Drawing.Size(560, 300);
-			this.lstDocuments.TabIndex = 0;
+			this.lstDocuments.TabIndex = 2;
+			this.lstDocuments.SelectedIndexChanged += new System.EventHandler(this.lstDocuments_SelectedIndexChanged);
 			this.lstDocuments.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
 				| System.Windows.Forms.AnchorStyles.Left)
 				| System.Windows.Forms.AnchorStyles.Right)));
@@ -49,24 +78,29 @@ namespace Chummer
 			// colName
 			//
 			this.colName.Text = "Name";
-			this.colName.Width = 280;
+			this.colName.Width = 220;
 			//
 			// colState
 			//
 			this.colState.Text = "Validation State";
-			this.colState.Width = 120;
+			this.colState.Width = 110;
 			//
 			// colUpdated
 			//
 			this.colUpdated.Text = "Updated";
-			this.colUpdated.Width = 140;
+			this.colUpdated.Width = 130;
+			//
+			// colShare
+			//
+			this.colShare.Text = "Share";
+			this.colShare.Width = 100;
 			//
 			// cmdLogin
 			//
-			this.cmdLogin.Location = new System.Drawing.Point(12, 320);
+			this.cmdLogin.Location = new System.Drawing.Point(12, 346);
 			this.cmdLogin.Name = "cmdLogin";
 			this.cmdLogin.Size = new System.Drawing.Size(90, 27);
-			this.cmdLogin.TabIndex = 1;
+			this.cmdLogin.TabIndex = 3;
 			this.cmdLogin.Tag = "Button_Cloud_Login";
 			this.cmdLogin.Text = "Log In";
 			this.cmdLogin.UseVisualStyleBackColor = true;
@@ -74,10 +108,10 @@ namespace Chummer
 			//
 			// cmdLogout
 			//
-			this.cmdLogout.Location = new System.Drawing.Point(108, 320);
+			this.cmdLogout.Location = new System.Drawing.Point(108, 346);
 			this.cmdLogout.Name = "cmdLogout";
 			this.cmdLogout.Size = new System.Drawing.Size(90, 27);
-			this.cmdLogout.TabIndex = 2;
+			this.cmdLogout.TabIndex = 4;
 			this.cmdLogout.Tag = "Button_Cloud_Logout";
 			this.cmdLogout.Text = "Log Out";
 			this.cmdLogout.UseVisualStyleBackColor = true;
@@ -85,10 +119,10 @@ namespace Chummer
 			//
 			// cmdRefresh
 			//
-			this.cmdRefresh.Location = new System.Drawing.Point(204, 320);
+			this.cmdRefresh.Location = new System.Drawing.Point(204, 346);
 			this.cmdRefresh.Name = "cmdRefresh";
 			this.cmdRefresh.Size = new System.Drawing.Size(90, 27);
-			this.cmdRefresh.TabIndex = 3;
+			this.cmdRefresh.TabIndex = 5;
 			this.cmdRefresh.Tag = "Button_Cloud_Refresh";
 			this.cmdRefresh.Text = "Refresh";
 			this.cmdRefresh.UseVisualStyleBackColor = true;
@@ -96,10 +130,10 @@ namespace Chummer
 			//
 			// cmdPushCurrent
 			//
-			this.cmdPushCurrent.Location = new System.Drawing.Point(300, 320);
+			this.cmdPushCurrent.Location = new System.Drawing.Point(300, 346);
 			this.cmdPushCurrent.Name = "cmdPushCurrent";
 			this.cmdPushCurrent.Size = new System.Drawing.Size(150, 27);
-			this.cmdPushCurrent.TabIndex = 4;
+			this.cmdPushCurrent.TabIndex = 6;
 			this.cmdPushCurrent.Tag = "Button_Cloud_PushCurrent";
 			this.cmdPushCurrent.Text = "Push Current Character";
 			this.cmdPushCurrent.UseVisualStyleBackColor = true;
@@ -107,10 +141,10 @@ namespace Chummer
 			//
 			// cmdDownload
 			//
-			this.cmdDownload.Location = new System.Drawing.Point(456, 320);
+			this.cmdDownload.Location = new System.Drawing.Point(456, 346);
 			this.cmdDownload.Name = "cmdDownload";
 			this.cmdDownload.Size = new System.Drawing.Size(115, 27);
-			this.cmdDownload.TabIndex = 5;
+			this.cmdDownload.TabIndex = 7;
 			this.cmdDownload.Tag = "Button_Cloud_Download";
 			this.cmdDownload.Text = "Download Selected";
 			this.cmdDownload.UseVisualStyleBackColor = true;
@@ -118,22 +152,34 @@ namespace Chummer
 			//
 			// cmdArchive
 			//
-			this.cmdArchive.Location = new System.Drawing.Point(12, 354);
+			this.cmdArchive.Location = new System.Drawing.Point(12, 380);
 			this.cmdArchive.Name = "cmdArchive";
 			this.cmdArchive.Size = new System.Drawing.Size(115, 27);
-			this.cmdArchive.TabIndex = 6;
+			this.cmdArchive.TabIndex = 8;
 			this.cmdArchive.Tag = "Button_Cloud_Archive";
 			this.cmdArchive.Text = "Archive Selected";
 			this.cmdArchive.UseVisualStyleBackColor = true;
 			this.cmdArchive.Click += new System.EventHandler(this.cmdArchive_Click);
 			//
+			// cmdPushShared
+			//
+			this.cmdPushShared.Location = new System.Drawing.Point(133, 380);
+			this.cmdPushShared.Name = "cmdPushShared";
+			this.cmdPushShared.Size = new System.Drawing.Size(180, 27);
+			this.cmdPushShared.TabIndex = 9;
+			this.cmdPushShared.Tag = "Button_Cloud_PushShared";
+			this.cmdPushShared.Text = "Push Update to Selected";
+			this.cmdPushShared.UseVisualStyleBackColor = true;
+			this.cmdPushShared.Visible = false;
+			this.cmdPushShared.Click += new System.EventHandler(this.cmdPushShared_Click);
+			//
 			// lblStatus
 			//
 			this.lblStatus.AutoSize = true;
-			this.lblStatus.Location = new System.Drawing.Point(12, 390);
+			this.lblStatus.Location = new System.Drawing.Point(12, 416);
 			this.lblStatus.Name = "lblStatus";
 			this.lblStatus.Size = new System.Drawing.Size(38, 13);
-			this.lblStatus.TabIndex = 7;
+			this.lblStatus.TabIndex = 10;
 			this.lblStatus.Text = "";
 			this.lblStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			//
@@ -141,8 +187,9 @@ namespace Chummer
 			//
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(584, 421);
+			this.ClientSize = new System.Drawing.Size(584, 447);
 			this.Controls.Add(this.lblStatus);
+			this.Controls.Add(this.cmdPushShared);
 			this.Controls.Add(this.cmdArchive);
 			this.Controls.Add(this.cmdDownload);
 			this.Controls.Add(this.cmdPushCurrent);
@@ -150,7 +197,9 @@ namespace Chummer
 			this.Controls.Add(this.cmdLogout);
 			this.Controls.Add(this.cmdLogin);
 			this.Controls.Add(this.lstDocuments);
-			this.MinimumSize = new System.Drawing.Size(500, 350);
+			this.Controls.Add(this.rdoSharedWithMe);
+			this.Controls.Add(this.rdoMyDocuments);
+			this.MinimumSize = new System.Drawing.Size(500, 376);
 			this.Name = "frmCloudDocuments";
 			this.Tag = "Title_CloudDocuments";
 			this.Text = "Cloud Documents";
@@ -159,16 +208,20 @@ namespace Chummer
 			this.PerformLayout();
 		}
 
+		private System.Windows.Forms.RadioButton rdoMyDocuments;
+		private System.Windows.Forms.RadioButton rdoSharedWithMe;
 		private System.Windows.Forms.ListView lstDocuments;
 		private System.Windows.Forms.ColumnHeader colName;
 		private System.Windows.Forms.ColumnHeader colState;
 		private System.Windows.Forms.ColumnHeader colUpdated;
+		private System.Windows.Forms.ColumnHeader colShare;
 		private System.Windows.Forms.Button cmdLogin;
 		private System.Windows.Forms.Button cmdLogout;
 		private System.Windows.Forms.Button cmdRefresh;
 		private System.Windows.Forms.Button cmdPushCurrent;
 		private System.Windows.Forms.Button cmdDownload;
 		private System.Windows.Forms.Button cmdArchive;
+		private System.Windows.Forms.Button cmdPushShared;
 		private System.Windows.Forms.Label lblStatus;
 	}
 }

--- a/Chummer/code/frmCloudDocuments.Designer.cs
+++ b/Chummer/code/frmCloudDocuments.Designer.cs
@@ -17,6 +17,9 @@ namespace Chummer
 		{
 			this.rdoMyDocuments = new System.Windows.Forms.RadioButton();
 			this.rdoSharedWithMe = new System.Windows.Forms.RadioButton();
+			this.lblApiToken = new System.Windows.Forms.Label();
+			this.txtApiToken = new System.Windows.Forms.TextBox();
+			this.cmdUseApiToken = new System.Windows.Forms.Button();
 			this.lstDocuments = new System.Windows.Forms.ListView();
 			this.colName = new System.Windows.Forms.ColumnHeader();
 			this.colState = new System.Windows.Forms.ColumnHeader();
@@ -55,6 +58,35 @@ namespace Chummer
 			this.rdoSharedWithMe.UseVisualStyleBackColor = true;
 			this.rdoSharedWithMe.CheckedChanged += new System.EventHandler(this.rdoDocumentMode_CheckedChanged);
 			//
+			// lblApiToken
+			//
+			this.lblApiToken.AutoSize = true;
+			this.lblApiToken.Location = new System.Drawing.Point(12, 41);
+			this.lblApiToken.Name = "lblApiToken";
+			this.lblApiToken.Size = new System.Drawing.Size(60, 13);
+			this.lblApiToken.TabIndex = 2;
+			this.lblApiToken.Tag = "Label_Cloud_ApiToken";
+			this.lblApiToken.Text = "API Token:";
+			//
+			// txtApiToken
+			//
+			this.txtApiToken.Location = new System.Drawing.Point(80, 38);
+			this.txtApiToken.Name = "txtApiToken";
+			this.txtApiToken.Size = new System.Drawing.Size(300, 20);
+			this.txtApiToken.TabIndex = 3;
+			this.txtApiToken.UseSystemPasswordChar = true;
+			//
+			// cmdUseApiToken
+			//
+			this.cmdUseApiToken.Location = new System.Drawing.Point(386, 36);
+			this.cmdUseApiToken.Name = "cmdUseApiToken";
+			this.cmdUseApiToken.Size = new System.Drawing.Size(90, 23);
+			this.cmdUseApiToken.TabIndex = 4;
+			this.cmdUseApiToken.Tag = "Button_Cloud_UseApiToken";
+			this.cmdUseApiToken.Text = "Use Token";
+			this.cmdUseApiToken.UseVisualStyleBackColor = true;
+			this.cmdUseApiToken.Click += new System.EventHandler(this.cmdUseApiToken_Click);
+			//
 			// lstDocuments
 			//
 			this.lstDocuments.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
@@ -66,10 +98,10 @@ namespace Chummer
 			this.lstDocuments.FullRowSelect = true;
 			this.lstDocuments.MultiSelect = false;
 			this.lstDocuments.HideSelection = false;
-			this.lstDocuments.Location = new System.Drawing.Point(12, 38);
+			this.lstDocuments.Location = new System.Drawing.Point(12, 64);
 			this.lstDocuments.Name = "lstDocuments";
 			this.lstDocuments.Size = new System.Drawing.Size(560, 300);
-			this.lstDocuments.TabIndex = 2;
+			this.lstDocuments.TabIndex = 5;
 			this.lstDocuments.SelectedIndexChanged += new System.EventHandler(this.lstDocuments_SelectedIndexChanged);
 			this.lstDocuments.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
 				| System.Windows.Forms.AnchorStyles.Left)
@@ -97,10 +129,10 @@ namespace Chummer
 			//
 			// cmdLogin
 			//
-			this.cmdLogin.Location = new System.Drawing.Point(12, 346);
+			this.cmdLogin.Location = new System.Drawing.Point(12, 372);
 			this.cmdLogin.Name = "cmdLogin";
 			this.cmdLogin.Size = new System.Drawing.Size(90, 27);
-			this.cmdLogin.TabIndex = 3;
+			this.cmdLogin.TabIndex = 6;
 			this.cmdLogin.Tag = "Button_Cloud_Login";
 			this.cmdLogin.Text = "Log In";
 			this.cmdLogin.UseVisualStyleBackColor = true;
@@ -108,10 +140,10 @@ namespace Chummer
 			//
 			// cmdLogout
 			//
-			this.cmdLogout.Location = new System.Drawing.Point(108, 346);
+			this.cmdLogout.Location = new System.Drawing.Point(108, 372);
 			this.cmdLogout.Name = "cmdLogout";
 			this.cmdLogout.Size = new System.Drawing.Size(90, 27);
-			this.cmdLogout.TabIndex = 4;
+			this.cmdLogout.TabIndex = 7;
 			this.cmdLogout.Tag = "Button_Cloud_Logout";
 			this.cmdLogout.Text = "Log Out";
 			this.cmdLogout.UseVisualStyleBackColor = true;
@@ -119,10 +151,10 @@ namespace Chummer
 			//
 			// cmdRefresh
 			//
-			this.cmdRefresh.Location = new System.Drawing.Point(204, 346);
+			this.cmdRefresh.Location = new System.Drawing.Point(204, 372);
 			this.cmdRefresh.Name = "cmdRefresh";
 			this.cmdRefresh.Size = new System.Drawing.Size(90, 27);
-			this.cmdRefresh.TabIndex = 5;
+			this.cmdRefresh.TabIndex = 8;
 			this.cmdRefresh.Tag = "Button_Cloud_Refresh";
 			this.cmdRefresh.Text = "Refresh";
 			this.cmdRefresh.UseVisualStyleBackColor = true;
@@ -130,10 +162,10 @@ namespace Chummer
 			//
 			// cmdPushCurrent
 			//
-			this.cmdPushCurrent.Location = new System.Drawing.Point(300, 346);
+			this.cmdPushCurrent.Location = new System.Drawing.Point(300, 372);
 			this.cmdPushCurrent.Name = "cmdPushCurrent";
 			this.cmdPushCurrent.Size = new System.Drawing.Size(150, 27);
-			this.cmdPushCurrent.TabIndex = 6;
+			this.cmdPushCurrent.TabIndex = 9;
 			this.cmdPushCurrent.Tag = "Button_Cloud_PushCurrent";
 			this.cmdPushCurrent.Text = "Push Current Character";
 			this.cmdPushCurrent.UseVisualStyleBackColor = true;
@@ -141,10 +173,10 @@ namespace Chummer
 			//
 			// cmdDownload
 			//
-			this.cmdDownload.Location = new System.Drawing.Point(456, 346);
+			this.cmdDownload.Location = new System.Drawing.Point(456, 372);
 			this.cmdDownload.Name = "cmdDownload";
 			this.cmdDownload.Size = new System.Drawing.Size(115, 27);
-			this.cmdDownload.TabIndex = 7;
+			this.cmdDownload.TabIndex = 10;
 			this.cmdDownload.Tag = "Button_Cloud_Download";
 			this.cmdDownload.Text = "Download Selected";
 			this.cmdDownload.UseVisualStyleBackColor = true;
@@ -152,10 +184,10 @@ namespace Chummer
 			//
 			// cmdArchive
 			//
-			this.cmdArchive.Location = new System.Drawing.Point(12, 380);
+			this.cmdArchive.Location = new System.Drawing.Point(12, 406);
 			this.cmdArchive.Name = "cmdArchive";
 			this.cmdArchive.Size = new System.Drawing.Size(115, 27);
-			this.cmdArchive.TabIndex = 8;
+			this.cmdArchive.TabIndex = 11;
 			this.cmdArchive.Tag = "Button_Cloud_Archive";
 			this.cmdArchive.Text = "Archive Selected";
 			this.cmdArchive.UseVisualStyleBackColor = true;
@@ -163,10 +195,10 @@ namespace Chummer
 			//
 			// cmdPushShared
 			//
-			this.cmdPushShared.Location = new System.Drawing.Point(133, 380);
+			this.cmdPushShared.Location = new System.Drawing.Point(133, 406);
 			this.cmdPushShared.Name = "cmdPushShared";
 			this.cmdPushShared.Size = new System.Drawing.Size(180, 27);
-			this.cmdPushShared.TabIndex = 9;
+			this.cmdPushShared.TabIndex = 12;
 			this.cmdPushShared.Tag = "Button_Cloud_PushShared";
 			this.cmdPushShared.Text = "Push Update to Selected";
 			this.cmdPushShared.UseVisualStyleBackColor = true;
@@ -176,10 +208,10 @@ namespace Chummer
 			// lblStatus
 			//
 			this.lblStatus.AutoSize = true;
-			this.lblStatus.Location = new System.Drawing.Point(12, 416);
+			this.lblStatus.Location = new System.Drawing.Point(12, 442);
 			this.lblStatus.Name = "lblStatus";
 			this.lblStatus.Size = new System.Drawing.Size(38, 13);
-			this.lblStatus.TabIndex = 10;
+			this.lblStatus.TabIndex = 13;
 			this.lblStatus.Text = "";
 			this.lblStatus.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
 			//
@@ -187,7 +219,7 @@ namespace Chummer
 			//
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-			this.ClientSize = new System.Drawing.Size(584, 447);
+			this.ClientSize = new System.Drawing.Size(584, 473);
 			this.Controls.Add(this.lblStatus);
 			this.Controls.Add(this.cmdPushShared);
 			this.Controls.Add(this.cmdArchive);
@@ -197,9 +229,12 @@ namespace Chummer
 			this.Controls.Add(this.cmdLogout);
 			this.Controls.Add(this.cmdLogin);
 			this.Controls.Add(this.lstDocuments);
+			this.Controls.Add(this.cmdUseApiToken);
+			this.Controls.Add(this.txtApiToken);
+			this.Controls.Add(this.lblApiToken);
 			this.Controls.Add(this.rdoSharedWithMe);
 			this.Controls.Add(this.rdoMyDocuments);
-			this.MinimumSize = new System.Drawing.Size(500, 376);
+			this.MinimumSize = new System.Drawing.Size(500, 402);
 			this.Name = "frmCloudDocuments";
 			this.Tag = "Title_CloudDocuments";
 			this.Text = "Cloud Documents";
@@ -210,6 +245,9 @@ namespace Chummer
 
 		private System.Windows.Forms.RadioButton rdoMyDocuments;
 		private System.Windows.Forms.RadioButton rdoSharedWithMe;
+		private System.Windows.Forms.Label lblApiToken;
+		private System.Windows.Forms.TextBox txtApiToken;
+		private System.Windows.Forms.Button cmdUseApiToken;
 		private System.Windows.Forms.ListView lstDocuments;
 		private System.Windows.Forms.ColumnHeader colName;
 		private System.Windows.Forms.ColumnHeader colState;

--- a/Chummer/code/frmCloudDocuments.Designer.cs
+++ b/Chummer/code/frmCloudDocuments.Designer.cs
@@ -102,6 +102,7 @@ namespace Chummer
 			this.txtApiToken.Size = new System.Drawing.Size(300, 20);
 			this.txtApiToken.TabIndex = 5;
 			this.txtApiToken.UseSystemPasswordChar = true;
+			this.txtApiToken.Enter += new System.EventHandler(this.txtApiToken_Enter);
 			//
 			// cmdUseApiToken
 			//

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -58,6 +58,20 @@ namespace Chummer
 			}
 		}
 
+		private async void cmdUseApiToken_Click(object sender, EventArgs e)
+		{
+			try
+			{
+				_objAuth.SetApiToken(txtApiToken.Text);
+				txtApiToken.Text = "";
+				await RefreshAsync();
+			}
+			catch (Exception ex)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_LoginFailed").Replace("{0}", ex.Message));
+			}
+		}
+
 		private void cmdLogout_Click(object sender, EventArgs e)
 		{
 			_objAuth.Logout();

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -592,5 +592,41 @@ namespace Chummer
 		{
 			lblStatus.Text = strText;
 		}
+
+#if DEBUG
+		/// <summary>
+		/// Debug-build-only: dumps connection state and, if a document is selected, the raw request/
+		/// response detail GetDebugDumpAsync exposes (full headers, both the typed and raw ETag parse,
+		/// the raw body) - the sort of detail that only ever surfaces by looking at the wire format
+		/// directly, not through the normal typed API surface.
+		/// </summary>
+		private async void cmdDebugInfo_Click(object sender, EventArgs e)
+		{
+			System.Text.StringBuilder objInfo = new System.Text.StringBuilder();
+			objInfo.AppendLine("CloudApiBaseUrl: " + GlobalOptions.Instance.CloudApiBaseUrl);
+			objInfo.AppendLine("HasStoredLogin: " + _objAuth.HasStoredLogin());
+			objInfo.AppendLine("IsApiTokenLogin: " + _objAuth.IsApiTokenLogin());
+			objInfo.AppendLine("GameProfileId: " + _strGameProfileId);
+			objInfo.AppendLine("GameProfileFormat: " + _strGameProfileFormat);
+
+			if (lstDocuments.SelectedItems.Count > 0 && lstDocuments.SelectedItems[0].Tag is RunnersPointDocument objDocument)
+			{
+				try
+				{
+					objInfo.AppendLine();
+					objInfo.Append(await _objApiClient.GetDebugDumpAsync(objDocument.Id));
+				}
+				catch (Exception ex)
+				{
+					objInfo.AppendLine();
+					objInfo.AppendLine("Failed to fetch document debug dump: " + ex);
+				}
+			}
+
+			string strInfo = objInfo.ToString();
+			Log.Debug("Cloud Documents debug info requested:{NewLine}{Info}", Environment.NewLine, strInfo);
+			MessageBox.Show(strInfo, "Cloud Documents Debug Info", MessageBoxButtons.OK, MessageBoxIcon.Information);
+		}
+#endif
 	}
 }

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -214,6 +214,11 @@ namespace Chummer
 		{
 			if (_objActiveCharacter == null)
 				return;
+			if (string.IsNullOrEmpty(_objActiveCharacter.FileName))
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotSavedLocally"));
+				return;
+			}
 
 			try
 			{
@@ -266,6 +271,11 @@ namespace Chummer
 		{
 			if (_objActiveCharacter == null || lstDocuments.SelectedItems.Count == 0)
 				return;
+			if (string.IsNullOrEmpty(_objActiveCharacter.FileName))
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotSavedLocally"));
+				return;
+			}
 			if (!(lstDocuments.SelectedItems[0].Tag is RunnersPointSharedDocument objDocument))
 				return;
 			if (objDocument.Permission != "write" || objDocument.ShareStatus != "active")

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -72,11 +72,15 @@ namespace Chummer
 		/// <summary>
 		/// Reflects whether/how we're actually logged in - separate from the short-lived cmdRefresh-style
 		/// messages in lblStatus, so "am I connected, and how" stays visible instead of getting
-		/// overwritten by the next status update.
+		/// overwritten by the next status update. Also keeps cmdLogout from staying clickable (and
+		/// implying there's something to log out of) once there's no stored login left.
 		/// </summary>
 		private void UpdateConnectionState()
 		{
-			if (!_objAuth.HasStoredLogin())
+			bool blnLoggedIn = _objAuth.HasStoredLogin();
+			cmdLogout.Enabled = blnLoggedIn;
+
+			if (!blnLoggedIn)
 			{
 				lblConnectionState.Text = LanguageManager.Instance.GetString("String_Cloud_ConnectionState_NotConnected");
 				return;

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -14,6 +14,8 @@ namespace Chummer
 	/// </summary>
 	public partial class frmCloudDocuments : Form
 	{
+		private const string DocumentType = "character";
+
 		private readonly RunnersPointAuth _objAuth = new RunnersPointAuth();
 		private RunnersPointApiClient _objApiClient;
 		private readonly Character _objActiveCharacter;
@@ -79,6 +81,17 @@ namespace Chummer
 			UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotLoggedIn"));
 		}
 
+		/// <summary>
+		/// Clears a stored login that the server no longer honors (expired or revoked) so the UI doesn't
+		/// just keep silently failing every call - the user needs to log in or paste a new token.
+		/// </summary>
+		private void HandleAuthExpired()
+		{
+			_objAuth.Logout();
+			lstDocuments.Items.Clear();
+			UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_AuthExpired"));
+		}
+
 		private async void rdoDocumentMode_CheckedChanged(object sender, EventArgs e)
 		{
 			// CheckedChanged fires for both the radio button losing and gaining the check - only react once.
@@ -109,8 +122,25 @@ namespace Chummer
 						UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NoGameProfile"));
 						return;
 					}
+					string strFormat = objProfile.Formats.FirstOrDefault(f => f == "application/xml") ?? objProfile.Formats.FirstOrDefault();
+					if (string.IsNullOrEmpty(strFormat))
+					{
+						UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NoGameProfile"));
+						return;
+					}
+
+					// The server advertises which document types/formats it actually accepts via
+					// Capabilities.documentTypes - verify "character"/strFormat is really one of them
+					// instead of just assuming it and letting create/pushRevision fail with a 422 later.
+					RunnersPointDocumentTypeCapability objCharacterType = objCapabilities.DocumentTypes.FirstOrDefault(t => t.Id == DocumentType);
+					if (objCharacterType == null || !objCharacterType.Formats.Any(f => f.MediaType == strFormat))
+					{
+						UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_UnsupportedDocumentType"));
+						return;
+					}
+
 					_strGameProfileId = objProfile.Id;
-					_strGameProfileFormat = objProfile.Formats.FirstOrDefault(f => f == "chum") ?? objProfile.Formats.FirstOrDefault() ?? "chum";
+					_strGameProfileFormat = strFormat;
 				}
 
 				lstDocuments.Items.Clear();
@@ -139,6 +169,10 @@ namespace Chummer
 				UpdateSelectionButtons();
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Ready"));
 			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+			{
+				HandleAuthExpired();
+			}
 			catch (Exception ex)
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
@@ -149,7 +183,12 @@ namespace Chummer
 		{
 			string strShare = "";
 			if (objDocument is RunnersPointSharedDocument objShared)
-				strShare = objShared.Permission + " (" + objShared.ShareStatus + ")";
+			{
+				strShare = objShared.Permission + " (" + objShared.ShareStatus;
+				if (objShared.ExpiresAt.HasValue)
+					strShare += ", expires " + objShared.ExpiresAt.Value.ToLocalTime().ToString("d");
+				strShare += ")";
+			}
 
 			ListViewItem objItem = new ListViewItem(new[]
 			{
@@ -205,6 +244,10 @@ namespace Chummer
 				UpdateStatus(strAccepted);
 				await RefreshAsync();
 			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+			{
+				HandleAuthExpired();
+			}
 			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushStale"));
@@ -253,6 +296,10 @@ namespace Chummer
 				UpdateStatus(strAccepted);
 				await RefreshAsync();
 			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+			{
+				HandleAuthExpired();
+			}
 			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushStale"));
@@ -285,19 +332,40 @@ namespace Chummer
 				return;
 			}
 
+			Tuple<byte[], string> objDownload;
+			try
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Downloading"));
+				objDownload = objDocument is RunnersPointSharedDocument
+					? await _objApiClient.DownloadSharedDocumentRevisionAsync(objDocument.Id, objDocument.CurrentRevision)
+					: await _objApiClient.DownloadRevisionAsync(objDocument.Id, objDocument.CurrentRevision);
+			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+			{
+				HandleAuthExpired();
+				return;
+			}
+			catch (Exception ex)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
+				return;
+			}
+
+			// Prefer the server's suggested filename (Content-Disposition) when it sent one; fall back to
+			// the document's own display name/id otherwise.
+			string strSuggestedFileName = !string.IsNullOrEmpty(objDownload.Item2)
+				? objDownload.Item2
+				: string.IsNullOrEmpty(objDocument.DisplayName) ? objDocument.Id : objDocument.DisplayName;
+
 			SaveFileDialog objDialog = new SaveFileDialog();
 			objDialog.Filter = "Chummer Files (*.chum)|*.chum|All Files (*.*)|*.*";
-			objDialog.FileName = string.IsNullOrEmpty(objDocument.DisplayName) ? objDocument.Id : objDocument.DisplayName;
+			objDialog.FileName = strSuggestedFileName;
 			if (objDialog.ShowDialog(this) != DialogResult.OK)
 				return;
 
 			try
 			{
-				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Downloading"));
-				byte[] bytContent = objDocument is RunnersPointSharedDocument
-					? await _objApiClient.DownloadSharedDocumentRevisionAsync(objDocument.Id, objDocument.CurrentRevision)
-					: await _objApiClient.DownloadRevisionAsync(objDocument.Id, objDocument.CurrentRevision);
-				File.WriteAllBytes(objDialog.FileName, bytContent);
+				File.WriteAllBytes(objDialog.FileName, objDownload.Item1);
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Ready"));
 			}
 			catch (Exception ex)
@@ -321,6 +389,10 @@ namespace Chummer
 				Tuple<RunnersPointDocument, string> objCurrent = await _objApiClient.GetDocumentAsync(objDocument.Id);
 				await _objApiClient.ArchiveDocumentAsync(objDocument.Id, objCurrent.Item2);
 				await RefreshAsync();
+			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+			{
+				HandleAuthExpired();
 			}
 			catch (Exception ex)
 			{

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -214,6 +214,10 @@ namespace Chummer
 			if (objDocument.Permission != "write" || objDocument.ShareStatus != "active")
 				return;
 
+			if (MessageBox.Show(LanguageManager.Instance.GetString("Message_Cloud_ConfirmPushShared").Replace("{0}", objDocument.DisplayName ?? objDocument.Id),
+				LanguageManager.Instance.GetString("MessageTitle_Cloud_ConfirmPushShared"), MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
+				return;
+
 			try
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Pushing"));

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -83,19 +83,24 @@ namespace Chummer
 					_strGameProfileFormat = objProfile.Formats.FirstOrDefault(f => f == "chum") ?? objProfile.Formats.FirstOrDefault() ?? "chum";
 				}
 
-				RunnersPointDocumentPage objPage = await _objApiClient.ListDocumentsAsync(_strGameProfileId);
 				lstDocuments.Items.Clear();
-				foreach (RunnersPointDocument objDocument in objPage.Items)
+				string strCursor = null;
+				do
 				{
-					ListViewItem objItem = new ListViewItem(new[]
+					RunnersPointDocumentPage objPage = await _objApiClient.ListDocumentsAsync(_strGameProfileId, strCursor);
+					foreach (RunnersPointDocument objDocument in objPage.Items)
 					{
-						string.IsNullOrEmpty(objDocument.DisplayName) ? objDocument.Id : objDocument.DisplayName,
-						objDocument.ValidationState,
-						objDocument.UpdatedAt.ToString("g"),
-					});
-					objItem.Tag = objDocument;
-					lstDocuments.Items.Add(objItem);
-				}
+						ListViewItem objItem = new ListViewItem(new[]
+						{
+							string.IsNullOrEmpty(objDocument.DisplayName) ? objDocument.Id : objDocument.DisplayName,
+							objDocument.ValidationState,
+							objDocument.UpdatedAt.ToString("g"),
+						});
+						objItem.Tag = objDocument;
+						lstDocuments.Items.Add(objItem);
+					}
+					strCursor = objPage.NextCursor;
+				} while (!string.IsNullOrEmpty(strCursor));
 
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Ready"));
 			}
@@ -110,6 +115,10 @@ namespace Chummer
 			await RefreshAsync();
 		}
 
+		// States in which a document's most recent revision hasn't finished the async quarantine/
+		// validation pipeline yet. Pushing on top of one of these would race the in-flight validation.
+		private static readonly string[] s_astrInFlightStates = { "quarantined", "scanning", "validating", "processing" };
+
 		private async void cmdPushCurrent_Click(object sender, EventArgs e)
 		{
 			if (_objActiveCharacter == null)
@@ -119,25 +128,38 @@ namespace Chummer
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Pushing"));
 				byte[] bytContent = File.ReadAllBytes(_objActiveCharacter.FileName);
+				RunnersPointRevisionStatus objStatus;
 
 				if (string.IsNullOrEmpty(_objActiveCharacter.CloudDocumentId))
 				{
-					RunnersPointRevisionStatus objStatus = await _objApiClient.CreateDocumentAsync(bytContent, _strGameProfileId, _strGameProfileFormat);
+					objStatus = await _objApiClient.CreateDocumentAsync(bytContent, _strGameProfileId, _strGameProfileFormat);
 					_objActiveCharacter.CloudDocumentId = objStatus.DocumentId;
 					_objActiveCharacter.Save();
 				}
 				else
 				{
 					Tuple<RunnersPointDocument, string> objCurrent = await _objApiClient.GetDocumentAsync(_objActiveCharacter.CloudDocumentId);
-					await _objApiClient.PushRevisionAsync(_objActiveCharacter.CloudDocumentId, bytContent, objCurrent.Item2, _strGameProfileId, _strGameProfileFormat);
+					if (s_astrInFlightStates.Contains(objCurrent.Item1.ValidationState))
+					{
+						UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushInFlight"));
+						return;
+					}
+					objStatus = await _objApiClient.PushRevisionAsync(_objActiveCharacter.CloudDocumentId, bytContent, objCurrent.Item2, _strGameProfileId, _strGameProfileFormat);
 				}
 
-				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushAccepted"));
+				string strAccepted = LanguageManager.Instance.GetString("String_Cloud_PushAccepted");
+				if (objStatus.Messages.Count > 0)
+					strAccepted += " " + string.Join(" ", objStatus.Messages);
+				UpdateStatus(strAccepted);
 				await RefreshAsync();
 			}
 			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushStale"));
+			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Conflict)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushIdempotencyConflict"));
 			}
 			catch (Exception ex)
 			{
@@ -145,11 +167,24 @@ namespace Chummer
 			}
 		}
 
+		// Whether downloadRevision is expected to work for a given document.validationState. The API
+		// doesn't currently document this (see open-questions doc: "whether warning-state revisions
+		// are downloadable" is unresolved) - "valid" and "warning" are the conservative assumption;
+		// "processing"/"rejected"/"archived" are blocked client-side with an explanation instead of
+		// just letting the download call fail with an unclear server error.
+		private static readonly string[] s_astrDownloadableStates = { "valid", "warning" };
+
 		private async void cmdDownload_Click(object sender, EventArgs e)
 		{
 			if (lstDocuments.SelectedItems.Count == 0)
 				return;
 			RunnersPointDocument objDocument = (RunnersPointDocument)lstDocuments.SelectedItems[0].Tag;
+
+			if (!s_astrDownloadableStates.Contains(objDocument.ValidationState))
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotDownloadable").Replace("{0}", objDocument.ValidationState));
+				return;
+			}
 
 			SaveFileDialog objDialog = new SaveFileDialog();
 			objDialog.Filter = "Chummer Files (*.chum)|*.chum|All Files (*.*)|*.*";

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -1,0 +1,200 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+
+namespace Chummer
+{
+	/// <summary>
+	/// Personal cloud storage/sync against the RunnersPoint Character Document Storage API. Replaces
+	/// the old Omae online-sharing feature - sharing/discovery of other users' content is explicitly
+	/// out of scope here (see docs/api/open-questions-character-document-storage-v1.md upstream), this
+	/// is purely "back up and recover my own characters."
+	/// </summary>
+	public partial class frmCloudDocuments : Form
+	{
+		private readonly RunnersPointAuth _objAuth = new RunnersPointAuth();
+		private RunnersPointApiClient _objApiClient;
+		private readonly Character _objActiveCharacter;
+		private string _strGameProfileId = "";
+		private string _strGameProfileFormat = "";
+
+		public frmCloudDocuments(Character objActiveCharacter)
+		{
+			_objActiveCharacter = objActiveCharacter;
+			InitializeComponent();
+			LanguageManager.Instance.Load(GlobalOptions.Instance.Language, this);
+		}
+
+		private async void frmCloudDocuments_Load(object sender, EventArgs e)
+		{
+			_objApiClient = new RunnersPointApiClient(_objAuth);
+			cmdPushCurrent.Enabled = _objActiveCharacter != null;
+
+			if (!_objAuth.HasStoredLogin())
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotLoggedIn"));
+				return;
+			}
+
+			await RefreshAsync();
+		}
+
+		private async void cmdLogin_Click(object sender, EventArgs e)
+		{
+			try
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_LoggingIn"));
+				await _objAuth.LoginAsync();
+				await RefreshAsync();
+			}
+			catch (Exception ex)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_LoginFailed").Replace("{0}", ex.Message));
+			}
+		}
+
+		private void cmdLogout_Click(object sender, EventArgs e)
+		{
+			_objAuth.Logout();
+			lstDocuments.Items.Clear();
+			UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotLoggedIn"));
+		}
+
+		private async System.Threading.Tasks.Task RefreshAsync()
+		{
+			try
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Refreshing"));
+
+				if (_strGameProfileId == "")
+				{
+					RunnersPointCapabilities objCapabilities = await _objApiClient.GetCapabilitiesAsync();
+					// Assumes the SR4 GameProfile is already provisioned server-side, per the RunnersPoint
+					// integration design - Chummer just needs to find it, not create it.
+					RunnersPointGameProfile objProfile = objCapabilities.GameProfiles.FirstOrDefault(
+						p => p.System.IndexOf("Shadowrun", StringComparison.OrdinalIgnoreCase) >= 0 && p.Edition.Contains("4"));
+					if (objProfile == null)
+					{
+						UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NoGameProfile"));
+						return;
+					}
+					_strGameProfileId = objProfile.Id;
+					_strGameProfileFormat = objProfile.Formats.FirstOrDefault(f => f == "chum") ?? objProfile.Formats.FirstOrDefault() ?? "chum";
+				}
+
+				RunnersPointDocumentPage objPage = await _objApiClient.ListDocumentsAsync(_strGameProfileId);
+				lstDocuments.Items.Clear();
+				foreach (RunnersPointDocument objDocument in objPage.Items)
+				{
+					ListViewItem objItem = new ListViewItem(new[]
+					{
+						string.IsNullOrEmpty(objDocument.DisplayName) ? objDocument.Id : objDocument.DisplayName,
+						objDocument.ValidationState,
+						objDocument.UpdatedAt.ToString("g"),
+					});
+					objItem.Tag = objDocument;
+					lstDocuments.Items.Add(objItem);
+				}
+
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Ready"));
+			}
+			catch (Exception ex)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
+			}
+		}
+
+		private async void cmdRefresh_Click(object sender, EventArgs e)
+		{
+			await RefreshAsync();
+		}
+
+		private async void cmdPushCurrent_Click(object sender, EventArgs e)
+		{
+			if (_objActiveCharacter == null)
+				return;
+
+			try
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Pushing"));
+				byte[] bytContent = File.ReadAllBytes(_objActiveCharacter.FileName);
+
+				if (string.IsNullOrEmpty(_objActiveCharacter.CloudDocumentId))
+				{
+					RunnersPointRevisionStatus objStatus = await _objApiClient.CreateDocumentAsync(bytContent, _strGameProfileId, _strGameProfileFormat);
+					_objActiveCharacter.CloudDocumentId = objStatus.DocumentId;
+					_objActiveCharacter.Save();
+				}
+				else
+				{
+					Tuple<RunnersPointDocument, string> objCurrent = await _objApiClient.GetDocumentAsync(_objActiveCharacter.CloudDocumentId);
+					await _objApiClient.PushRevisionAsync(_objActiveCharacter.CloudDocumentId, bytContent, objCurrent.Item2, _strGameProfileId, _strGameProfileFormat);
+				}
+
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushAccepted"));
+				await RefreshAsync();
+			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushStale"));
+			}
+			catch (Exception ex)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
+			}
+		}
+
+		private async void cmdDownload_Click(object sender, EventArgs e)
+		{
+			if (lstDocuments.SelectedItems.Count == 0)
+				return;
+			RunnersPointDocument objDocument = (RunnersPointDocument)lstDocuments.SelectedItems[0].Tag;
+
+			SaveFileDialog objDialog = new SaveFileDialog();
+			objDialog.Filter = "Chummer Files (*.chum)|*.chum|All Files (*.*)|*.*";
+			objDialog.FileName = string.IsNullOrEmpty(objDocument.DisplayName) ? objDocument.Id : objDocument.DisplayName;
+			if (objDialog.ShowDialog(this) != DialogResult.OK)
+				return;
+
+			try
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Downloading"));
+				byte[] bytContent = await _objApiClient.DownloadRevisionAsync(objDocument.Id, objDocument.CurrentRevision);
+				File.WriteAllBytes(objDialog.FileName, bytContent);
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Ready"));
+			}
+			catch (Exception ex)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
+			}
+		}
+
+		private async void cmdArchive_Click(object sender, EventArgs e)
+		{
+			if (lstDocuments.SelectedItems.Count == 0)
+				return;
+			RunnersPointDocument objDocument = (RunnersPointDocument)lstDocuments.SelectedItems[0].Tag;
+
+			if (MessageBox.Show(LanguageManager.Instance.GetString("Message_Cloud_ConfirmArchive").Replace("{0}", objDocument.DisplayName ?? objDocument.Id),
+				LanguageManager.Instance.GetString("MessageTitle_Cloud_ConfirmArchive"), MessageBoxButtons.YesNo, MessageBoxIcon.Warning) != DialogResult.Yes)
+				return;
+
+			try
+			{
+				Tuple<RunnersPointDocument, string> objCurrent = await _objApiClient.GetDocumentAsync(objDocument.Id);
+				await _objApiClient.ArchiveDocumentAsync(objDocument.Id, objCurrent.Item2);
+				await RefreshAsync();
+			}
+			catch (Exception ex)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
+			}
+		}
+
+		private void UpdateStatus(string strText)
+		{
+			lblStatus.Text = strText;
+		}
+	}
+}

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -7,9 +7,10 @@ namespace Chummer
 {
 	/// <summary>
 	/// Personal cloud storage/sync against the RunnersPoint Character Document Storage API. Replaces
-	/// the old Omae online-sharing feature - sharing/discovery of other users' content is explicitly
-	/// out of scope here (see docs/api/open-questions-character-document-storage-v1.md upstream), this
-	/// is purely "back up and recover my own characters."
+	/// the old Omae online-sharing feature. Covers two surfaces: the user's own documents
+	/// (create/push/download/archive), and documents explicitly shared with the user by someone else
+	/// (browse/download, and push an update if the grant is read-write) - there is no public
+	/// marketplace/discovery here, that lives on the RunnersPoint website.
 	/// </summary>
 	public partial class frmCloudDocuments : Form
 	{
@@ -18,6 +19,8 @@ namespace Chummer
 		private readonly Character _objActiveCharacter;
 		private string _strGameProfileId = "";
 		private string _strGameProfileFormat = "";
+
+		private bool SharedMode => rdoSharedWithMe.Checked;
 
 		public frmCloudDocuments(Character objActiveCharacter)
 		{
@@ -30,6 +33,7 @@ namespace Chummer
 		{
 			_objApiClient = new RunnersPointApiClient(_objAuth);
 			cmdPushCurrent.Enabled = _objActiveCharacter != null;
+			UpdateSelectionButtons();
 
 			if (!_objAuth.HasStoredLogin())
 			{
@@ -61,6 +65,18 @@ namespace Chummer
 			UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotLoggedIn"));
 		}
 
+		private async void rdoDocumentMode_CheckedChanged(object sender, EventArgs e)
+		{
+			// CheckedChanged fires for both the radio button losing and gaining the check - only react once.
+			if (sender is RadioButton radio && !radio.Checked)
+				return;
+
+			cmdPushCurrent.Enabled = !SharedMode && _objActiveCharacter != null;
+			cmdArchive.Visible = !SharedMode;
+			cmdPushShared.Visible = SharedMode;
+			await RefreshAsync();
+		}
+
 		private async System.Threading.Tasks.Task RefreshAsync()
 		{
 			try
@@ -85,29 +101,51 @@ namespace Chummer
 
 				lstDocuments.Items.Clear();
 				string strCursor = null;
-				do
+				if (SharedMode)
 				{
-					RunnersPointDocumentPage objPage = await _objApiClient.ListDocumentsAsync(_strGameProfileId, strCursor);
-					foreach (RunnersPointDocument objDocument in objPage.Items)
+					do
 					{
-						ListViewItem objItem = new ListViewItem(new[]
-						{
-							string.IsNullOrEmpty(objDocument.DisplayName) ? objDocument.Id : objDocument.DisplayName,
-							objDocument.ValidationState,
-							objDocument.UpdatedAt.ToString("g"),
-						});
-						objItem.Tag = objDocument;
-						lstDocuments.Items.Add(objItem);
-					}
-					strCursor = objPage.NextCursor;
-				} while (!string.IsNullOrEmpty(strCursor));
+						RunnersPointSharedDocumentPage objPage = await _objApiClient.ListSharedDocumentsAsync(_strGameProfileId, strCursor);
+						foreach (RunnersPointSharedDocument objDocument in objPage.Items)
+							lstDocuments.Items.Add(BuildListItem(objDocument));
+						strCursor = objPage.NextCursor;
+					} while (!string.IsNullOrEmpty(strCursor));
+				}
+				else
+				{
+					do
+					{
+						RunnersPointDocumentPage objPage = await _objApiClient.ListDocumentsAsync(_strGameProfileId, strCursor);
+						foreach (RunnersPointDocument objDocument in objPage.Items)
+							lstDocuments.Items.Add(BuildListItem(objDocument));
+						strCursor = objPage.NextCursor;
+					} while (!string.IsNullOrEmpty(strCursor));
+				}
 
+				UpdateSelectionButtons();
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Ready"));
 			}
 			catch (Exception ex)
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
 			}
+		}
+
+		private static ListViewItem BuildListItem(RunnersPointDocument objDocument)
+		{
+			string strShare = "";
+			if (objDocument is RunnersPointSharedDocument objShared)
+				strShare = objShared.Permission + " (" + objShared.ShareStatus + ")";
+
+			ListViewItem objItem = new ListViewItem(new[]
+			{
+				string.IsNullOrEmpty(objDocument.DisplayName) ? objDocument.Id : objDocument.DisplayName,
+				objDocument.ValidationState,
+				objDocument.UpdatedAt.ToString("g"),
+				strShare,
+			});
+			objItem.Tag = objDocument;
+			return objItem;
 		}
 
 		private async void cmdRefresh_Click(object sender, EventArgs e)
@@ -117,7 +155,7 @@ namespace Chummer
 
 		// States in which a document's most recent revision hasn't finished the async quarantine/
 		// validation pipeline yet. Pushing on top of one of these would race the in-flight validation.
-		private static readonly string[] s_astrInFlightStates = { "quarantined", "scanning", "validating", "processing" };
+		private static readonly string[] s_astrInFlightStates = { "quarantined", "processing" };
 
 		private async void cmdPushCurrent_Click(object sender, EventArgs e)
 		{
@@ -167,12 +205,55 @@ namespace Chummer
 			}
 		}
 
-		// Whether downloadRevision is expected to work for a given document.validationState. The API
-		// doesn't currently document this (see open-questions doc: "whether warning-state revisions
-		// are downloadable" is unresolved) - "valid" and "warning" are the conservative assumption;
-		// "processing"/"rejected"/"archived" are blocked client-side with an explanation instead of
-		// just letting the download call fail with an unclear server error.
-		private static readonly string[] s_astrDownloadableStates = { "valid", "warning" };
+		private async void cmdPushShared_Click(object sender, EventArgs e)
+		{
+			if (_objActiveCharacter == null || lstDocuments.SelectedItems.Count == 0)
+				return;
+			if (!(lstDocuments.SelectedItems[0].Tag is RunnersPointSharedDocument objDocument))
+				return;
+			if (objDocument.Permission != "write" || objDocument.ShareStatus != "active")
+				return;
+
+			try
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Pushing"));
+				byte[] bytContent = File.ReadAllBytes(_objActiveCharacter.FileName);
+
+				Tuple<RunnersPointSharedDocument, string> objCurrent = await _objApiClient.GetSharedDocumentAsync(objDocument.Id);
+				if (s_astrInFlightStates.Contains(objCurrent.Item1.ValidationState))
+				{
+					UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushInFlight"));
+					return;
+				}
+
+				RunnersPointRevisionStatus objStatus = await _objApiClient.PushSharedDocumentRevisionAsync(
+					objDocument.Id, bytContent, objCurrent.Item2, _strGameProfileId, _strGameProfileFormat);
+
+				string strAccepted = LanguageManager.Instance.GetString("String_Cloud_PushAccepted");
+				if (objStatus.Messages.Count > 0)
+					strAccepted += " " + string.Join(" ", objStatus.Messages);
+				UpdateStatus(strAccepted);
+				await RefreshAsync();
+			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.PreconditionFailed)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushStale"));
+			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Conflict)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_PushIdempotencyConflict"));
+			}
+			catch (Exception ex)
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
+			}
+		}
+
+		// Whether downloadRevision is expected to work for a given document.validationState - "accepted"
+		// is the only state with a validated, servable revision; everything else (quarantined/processing/
+		// rejected/archived) is blocked client-side with an explanation instead of letting the download
+		// call fail with an unclear server error.
+		private static readonly string[] s_astrDownloadableStates = { "accepted" };
 
 		private async void cmdDownload_Click(object sender, EventArgs e)
 		{
@@ -195,7 +276,9 @@ namespace Chummer
 			try
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Downloading"));
-				byte[] bytContent = await _objApiClient.DownloadRevisionAsync(objDocument.Id, objDocument.CurrentRevision);
+				byte[] bytContent = objDocument is RunnersPointSharedDocument
+					? await _objApiClient.DownloadSharedDocumentRevisionAsync(objDocument.Id, objDocument.CurrentRevision)
+					: await _objApiClient.DownloadRevisionAsync(objDocument.Id, objDocument.CurrentRevision);
 				File.WriteAllBytes(objDialog.FileName, bytContent);
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Ready"));
 			}
@@ -207,7 +290,7 @@ namespace Chummer
 
 		private async void cmdArchive_Click(object sender, EventArgs e)
 		{
-			if (lstDocuments.SelectedItems.Count == 0)
+			if (SharedMode || lstDocuments.SelectedItems.Count == 0)
 				return;
 			RunnersPointDocument objDocument = (RunnersPointDocument)lstDocuments.SelectedItems[0].Tag;
 
@@ -225,6 +308,28 @@ namespace Chummer
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
 			}
+		}
+
+		private void lstDocuments_SelectedIndexChanged(object sender, EventArgs e)
+		{
+			UpdateSelectionButtons();
+		}
+
+		private void UpdateSelectionButtons()
+		{
+			if (lstDocuments.SelectedItems.Count == 0)
+			{
+				cmdDownload.Enabled = false;
+				cmdArchive.Enabled = false;
+				cmdPushShared.Enabled = false;
+				return;
+			}
+
+			object objTag = lstDocuments.SelectedItems[0].Tag;
+			cmdDownload.Enabled = true;
+			cmdArchive.Enabled = !SharedMode;
+			cmdPushShared.Enabled = SharedMode && _objActiveCharacter != null && objTag is RunnersPointSharedDocument objShared
+				&& objShared.Permission == "write" && objShared.ShareStatus == "active";
 		}
 
 		private void UpdateStatus(string strText)

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -2,6 +2,7 @@ using System;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
+using Serilog;
 
 namespace Chummer
 {
@@ -56,6 +57,7 @@ namespace Chummer
 			}
 			catch (Exception ex)
 			{
+				Log.Error(ex, "RunnersPoint login failed");
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_LoginFailed").Replace("{0}", ex.Message));
 			}
 		}
@@ -70,6 +72,7 @@ namespace Chummer
 			}
 			catch (Exception ex)
 			{
+				Log.Error(ex, "RunnersPoint login failed");
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_LoginFailed").Replace("{0}", ex.Message));
 			}
 		}
@@ -87,6 +90,7 @@ namespace Chummer
 		/// </summary>
 		private void HandleAuthExpired()
 		{
+			Log.Warning("RunnersPoint login rejected as expired/revoked (401) - clearing stored login");
 			_objAuth.Logout();
 			lstDocuments.Items.Clear();
 			UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_AuthExpired"));
@@ -175,6 +179,7 @@ namespace Chummer
 			}
 			catch (Exception ex)
 			{
+				Log.Error(ex, "Cloud Documents operation failed");
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
 			}
 		}
@@ -263,6 +268,7 @@ namespace Chummer
 			}
 			catch (Exception ex)
 			{
+				Log.Error(ex, "Cloud Documents operation failed");
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
 			}
 		}
@@ -320,6 +326,7 @@ namespace Chummer
 			}
 			catch (Exception ex)
 			{
+				Log.Error(ex, "Cloud Documents operation failed");
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
 			}
 		}
@@ -380,6 +387,7 @@ namespace Chummer
 			}
 			catch (Exception ex)
 			{
+				Log.Error(ex, "Cloud Documents operation failed");
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
 			}
 		}
@@ -406,6 +414,7 @@ namespace Chummer
 			}
 			catch (Exception ex)
 			{
+				Log.Error(ex, "Cloud Documents operation failed");
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
 			}
 		}

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -17,6 +17,12 @@ namespace Chummer
 	{
 		private const string DocumentType = "character";
 
+		// Masked placeholder shown in the API Token field when a token is already stored, so the field
+		// isn't just blank and misleadingly implying nothing is configured. Never submitted as-is - it's
+		// cleared as soon as the field gets focus, or ignored if somehow submitted unchanged.
+		private const string ApiTokenPlaceholder = "................................";
+		private bool _blnApiTokenPlaceholderShown;
+
 		private readonly RunnersPointAuth _objAuth = new RunnersPointAuth();
 		private RunnersPointApiClient _objApiClient;
 		private readonly Character _objActiveCharacter;
@@ -44,6 +50,7 @@ namespace Chummer
 				rdoAuthOAuth.Checked = true;
 			UpdateAuthModeVisibility();
 			UpdateConnectionState();
+			UpdateApiTokenPlaceholder();
 
 			if (!_objAuth.HasStoredLogin())
 			{
@@ -67,6 +74,33 @@ namespace Chummer
 			txtApiToken.Visible = rdoAuthApiToken.Checked;
 			cmdUseApiToken.Visible = rdoAuthApiToken.Checked;
 			cmdLogin.Visible = rdoAuthOAuth.Checked;
+		}
+
+		/// <summary>
+		/// Fills the API Token field with a masked placeholder when a token is already stored, so the
+		/// field visibly says "something's configured" instead of looking empty/unset. Clears back out
+		/// (via txtApiToken_Enter) the moment the user actually focuses the field to type a new one.
+		/// </summary>
+		private void UpdateApiTokenPlaceholder()
+		{
+			if (_objAuth.HasStoredLogin() && _objAuth.IsApiTokenLogin())
+			{
+				txtApiToken.Text = ApiTokenPlaceholder;
+				_blnApiTokenPlaceholderShown = true;
+			}
+			else
+			{
+				txtApiToken.Text = "";
+				_blnApiTokenPlaceholderShown = false;
+			}
+		}
+
+		private void txtApiToken_Enter(object sender, EventArgs e)
+		{
+			if (!_blnApiTokenPlaceholderShown)
+				return;
+			txtApiToken.Text = "";
+			_blnApiTokenPlaceholderShown = false;
 		}
 
 		/// <summary>
@@ -98,7 +132,13 @@ namespace Chummer
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_LoggingIn"));
 				await _objAuth.LoginAsync();
 				UpdateConnectionState();
+				UpdateApiTokenPlaceholder();
 				await RefreshAsync();
+			}
+			catch (System.Net.Http.HttpRequestException ex)
+			{
+				Log.Warning(ex, "RunnersPoint server unreachable");
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_ServerUnreachable"));
 			}
 			catch (Exception ex)
 			{
@@ -109,12 +149,22 @@ namespace Chummer
 
 		private async void cmdUseApiToken_Click(object sender, EventArgs e)
 		{
+			// Nothing was actually typed - the field still shows the "a token is stored" placeholder,
+			// not a real value to submit.
+			if (_blnApiTokenPlaceholderShown)
+				return;
+
 			try
 			{
 				_objAuth.SetApiToken(txtApiToken.Text);
-				txtApiToken.Text = "";
 				UpdateConnectionState();
+				UpdateApiTokenPlaceholder();
 				await RefreshAsync();
+			}
+			catch (System.Net.Http.HttpRequestException ex)
+			{
+				Log.Warning(ex, "RunnersPoint server unreachable");
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_ServerUnreachable"));
 			}
 			catch (Exception ex)
 			{
@@ -128,6 +178,7 @@ namespace Chummer
 			_objAuth.Logout();
 			lstDocuments.Items.Clear();
 			UpdateConnectionState();
+			UpdateApiTokenPlaceholder();
 			UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotLoggedIn"));
 		}
 
@@ -141,6 +192,7 @@ namespace Chummer
 			_objAuth.Logout();
 			lstDocuments.Items.Clear();
 			UpdateConnectionState();
+			UpdateApiTokenPlaceholder();
 			UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_AuthExpired"));
 		}
 
@@ -224,6 +276,14 @@ namespace Chummer
 			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
 			{
 				HandleAuthExpired();
+			}
+			catch (System.Net.Http.HttpRequestException ex)
+			{
+				// Distinguished from "wrong/expired credentials" - the login itself is still fine, the
+				// server just isn't reachable right now (offline, wrong CloudApiBaseUrl, DNS/connection
+				// failure). Don't wipe the stored login over what's likely a transient network problem.
+				Log.Warning(ex, "RunnersPoint server unreachable");
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_ServerUnreachable"));
 			}
 			catch (Exception ex)
 			{

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -42,6 +42,7 @@ namespace Chummer
 		{
 			_objApiClient = new RunnersPointApiClient(_objAuth);
 			cmdPushCurrent.Enabled = _objActiveCharacter != null;
+			cmdEditMetadata.Enabled = _objActiveCharacter != null;
 			UpdateSelectionButtons();
 
 			// Reflect whatever's actually stored, rather than always defaulting to the API Token radio,
@@ -317,6 +318,15 @@ namespace Chummer
 		private async void cmdRefresh_Click(object sender, EventArgs e)
 		{
 			await RefreshAsync();
+		}
+
+		private void cmdEditMetadata_Click(object sender, EventArgs e)
+		{
+			if (_objActiveCharacter == null)
+				return;
+
+			using (frmCloudMetadata frmMetadata = new frmCloudMetadata(_objActiveCharacter))
+				frmMetadata.ShowDialog(this);
 		}
 
 		// States in which a document's most recent revision hasn't finished the async quarantine/

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -390,6 +390,29 @@ namespace Chummer
 			if (lstDocuments.SelectedItems.Count == 0)
 				return;
 			RunnersPointDocument objDocument = (RunnersPointDocument)lstDocuments.SelectedItems[0].Tag;
+			bool blnShared = objDocument is RunnersPointSharedDocument;
+
+			// Re-fetch the document immediately before downloading rather than trusting the list
+			// snapshot - it may have gone stale (someone else pushed a new revision, or it moved out of
+			// a downloadable state) since the list was last refreshed.
+			try
+			{
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Refreshing"));
+				objDocument = blnShared
+					? (await _objApiClient.GetSharedDocumentAsync(objDocument.Id)).Item1
+					: (await _objApiClient.GetDocumentAsync(objDocument.Id)).Item1;
+			}
+			catch (RunnersPointApiException ex) when (ex.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+			{
+				HandleAuthExpired();
+				return;
+			}
+			catch (Exception ex)
+			{
+				Log.Error(ex, "Cloud Documents operation failed");
+				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
+				return;
+			}
 
 			if (!s_astrDownloadableStates.Contains(objDocument.ValidationState))
 			{
@@ -401,7 +424,7 @@ namespace Chummer
 			try
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Downloading"));
-				objDownload = objDocument is RunnersPointSharedDocument
+				objDownload = blnShared
 					? await _objApiClient.DownloadSharedDocumentRevisionAsync(objDocument.Id, objDocument.CurrentRevision)
 					: await _objApiClient.DownloadRevisionAsync(objDocument.Id, objDocument.CurrentRevision);
 			}
@@ -412,6 +435,7 @@ namespace Chummer
 			}
 			catch (Exception ex)
 			{
+				Log.Error(ex, "Cloud Documents operation failed");
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Error").Replace("{0}", ex.Message));
 				return;
 			}
@@ -431,7 +455,22 @@ namespace Chummer
 			try
 			{
 				File.WriteAllBytes(objDialog.FileName, objDownload.Item1);
+
+				// Make sure the saved file is linked back to the document it came from - a character
+				// downloaded from somewhere else may never have had CloudDocumentId set, and without it
+				// a later push from the opened character would create a duplicate document instead of
+				// updating this one.
+				Character objDownloaded = new Character { FileName = objDialog.FileName };
+				if (objDownloaded.Load() && string.IsNullOrEmpty(objDownloaded.CloudDocumentId))
+				{
+					objDownloaded.CloudDocumentId = objDocument.Id;
+					objDownloaded.Save();
+				}
+
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_Ready"));
+
+				if (this.Owner is frmMain frmMainForm)
+					frmMainForm.LoadCharacter(objDialog.FileName);
 			}
 			catch (Exception ex)
 			{

--- a/Chummer/code/frmCloudDocuments.cs
+++ b/Chummer/code/frmCloudDocuments.cs
@@ -38,6 +38,13 @@ namespace Chummer
 			cmdPushCurrent.Enabled = _objActiveCharacter != null;
 			UpdateSelectionButtons();
 
+			// Reflect whatever's actually stored, rather than always defaulting to the API Token radio,
+			// so the UI doesn't contradict a login made via the other method in an earlier session.
+			if (_objAuth.HasStoredLogin() && !_objAuth.IsApiTokenLogin())
+				rdoAuthOAuth.Checked = true;
+			UpdateAuthModeVisibility();
+			UpdateConnectionState();
+
 			if (!_objAuth.HasStoredLogin())
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotLoggedIn"));
@@ -47,12 +54,46 @@ namespace Chummer
 			await RefreshAsync();
 		}
 
+		private void rdoAuthMode_CheckedChanged(object sender, EventArgs e)
+		{
+			if (sender is RadioButton radio && !radio.Checked)
+				return;
+			UpdateAuthModeVisibility();
+		}
+
+		private void UpdateAuthModeVisibility()
+		{
+			lblApiToken.Visible = rdoAuthApiToken.Checked;
+			txtApiToken.Visible = rdoAuthApiToken.Checked;
+			cmdUseApiToken.Visible = rdoAuthApiToken.Checked;
+			cmdLogin.Visible = rdoAuthOAuth.Checked;
+		}
+
+		/// <summary>
+		/// Reflects whether/how we're actually logged in - separate from the short-lived cmdRefresh-style
+		/// messages in lblStatus, so "am I connected, and how" stays visible instead of getting
+		/// overwritten by the next status update.
+		/// </summary>
+		private void UpdateConnectionState()
+		{
+			if (!_objAuth.HasStoredLogin())
+			{
+				lblConnectionState.Text = LanguageManager.Instance.GetString("String_Cloud_ConnectionState_NotConnected");
+				return;
+			}
+
+			lblConnectionState.Text = _objAuth.IsApiTokenLogin()
+				? LanguageManager.Instance.GetString("String_Cloud_ConnectionState_ApiToken")
+				: LanguageManager.Instance.GetString("String_Cloud_ConnectionState_OAuth");
+		}
+
 		private async void cmdLogin_Click(object sender, EventArgs e)
 		{
 			try
 			{
 				UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_LoggingIn"));
 				await _objAuth.LoginAsync();
+				UpdateConnectionState();
 				await RefreshAsync();
 			}
 			catch (Exception ex)
@@ -68,6 +109,7 @@ namespace Chummer
 			{
 				_objAuth.SetApiToken(txtApiToken.Text);
 				txtApiToken.Text = "";
+				UpdateConnectionState();
 				await RefreshAsync();
 			}
 			catch (Exception ex)
@@ -81,6 +123,7 @@ namespace Chummer
 		{
 			_objAuth.Logout();
 			lstDocuments.Items.Clear();
+			UpdateConnectionState();
 			UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_NotLoggedIn"));
 		}
 
@@ -93,6 +136,7 @@ namespace Chummer
 			Log.Warning("RunnersPoint login rejected as expired/revoked (401) - clearing stored login");
 			_objAuth.Logout();
 			lstDocuments.Items.Clear();
+			UpdateConnectionState();
 			UpdateStatus(LanguageManager.Instance.GetString("String_Cloud_AuthExpired"));
 		}
 

--- a/Chummer/code/frmCloudMetadata.Designer.cs
+++ b/Chummer/code/frmCloudMetadata.Designer.cs
@@ -1,0 +1,148 @@
+namespace Chummer
+{
+	partial class frmCloudMetadata
+	{
+		private System.ComponentModel.IContainer components = null;
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && (components != null))
+			{
+				components.Dispose();
+			}
+			base.Dispose(disposing);
+		}
+
+		private void InitializeComponent()
+		{
+			this.lblNote = new System.Windows.Forms.Label();
+			this.lblDisplayName = new System.Windows.Forms.Label();
+			this.txtDisplayName = new System.Windows.Forms.TextBox();
+			this.lblDescription = new System.Windows.Forms.Label();
+			this.txtDescription = new System.Windows.Forms.TextBox();
+			this.lblImageUrl = new System.Windows.Forms.Label();
+			this.txtImageUrl = new System.Windows.Forms.TextBox();
+			this.cmdOK = new System.Windows.Forms.Button();
+			this.cmdCancel = new System.Windows.Forms.Button();
+			this.SuspendLayout();
+			//
+			// lblNote
+			//
+			this.lblNote.Location = new System.Drawing.Point(12, 9);
+			this.lblNote.Name = "lblNote";
+			this.lblNote.Size = new System.Drawing.Size(430, 32);
+			this.lblNote.TabIndex = 0;
+			this.lblNote.Tag = "Label_CloudMetadata_Note";
+			this.lblNote.Text = "Not sent to RunnersPoint yet - the server has no way to accept this from a client. Stored locally so it isn\'t lost once it can.";
+			//
+			// lblDisplayName
+			//
+			this.lblDisplayName.AutoSize = true;
+			this.lblDisplayName.Location = new System.Drawing.Point(12, 50);
+			this.lblDisplayName.Name = "lblDisplayName";
+			this.lblDisplayName.Size = new System.Drawing.Size(78, 13);
+			this.lblDisplayName.TabIndex = 1;
+			this.lblDisplayName.Tag = "Label_CloudMetadata_DisplayName";
+			this.lblDisplayName.Text = "Display Name:";
+			//
+			// txtDisplayName
+			//
+			this.txtDisplayName.Location = new System.Drawing.Point(110, 47);
+			this.txtDisplayName.Name = "txtDisplayName";
+			this.txtDisplayName.Size = new System.Drawing.Size(330, 20);
+			this.txtDisplayName.TabIndex = 2;
+			//
+			// lblDescription
+			//
+			this.lblDescription.AutoSize = true;
+			this.lblDescription.Location = new System.Drawing.Point(12, 76);
+			this.lblDescription.Name = "lblDescription";
+			this.lblDescription.Size = new System.Drawing.Size(63, 13);
+			this.lblDescription.TabIndex = 3;
+			this.lblDescription.Tag = "Label_CloudMetadata_Description";
+			this.lblDescription.Text = "Description:";
+			//
+			// txtDescription
+			//
+			this.txtDescription.Location = new System.Drawing.Point(110, 76);
+			this.txtDescription.Multiline = true;
+			this.txtDescription.Name = "txtDescription";
+			this.txtDescription.Size = new System.Drawing.Size(330, 80);
+			this.txtDescription.TabIndex = 4;
+			//
+			// lblImageUrl
+			//
+			this.lblImageUrl.AutoSize = true;
+			this.lblImageUrl.Location = new System.Drawing.Point(12, 164);
+			this.lblImageUrl.Name = "lblImageUrl";
+			this.lblImageUrl.Size = new System.Drawing.Size(56, 13);
+			this.lblImageUrl.TabIndex = 5;
+			this.lblImageUrl.Tag = "Label_CloudMetadata_ImageUrl";
+			this.lblImageUrl.Text = "Image URL:";
+			//
+			// txtImageUrl
+			//
+			this.txtImageUrl.Location = new System.Drawing.Point(110, 161);
+			this.txtImageUrl.Name = "txtImageUrl";
+			this.txtImageUrl.Size = new System.Drawing.Size(330, 20);
+			this.txtImageUrl.TabIndex = 6;
+			//
+			// cmdOK
+			//
+			this.cmdOK.Location = new System.Drawing.Point(285, 195);
+			this.cmdOK.Name = "cmdOK";
+			this.cmdOK.Size = new System.Drawing.Size(75, 27);
+			this.cmdOK.TabIndex = 7;
+			this.cmdOK.Tag = "String_OK";
+			this.cmdOK.Text = "OK";
+			this.cmdOK.UseVisualStyleBackColor = true;
+			this.cmdOK.Click += new System.EventHandler(this.cmdOK_Click);
+			//
+			// cmdCancel
+			//
+			this.cmdCancel.Location = new System.Drawing.Point(366, 195);
+			this.cmdCancel.Name = "cmdCancel";
+			this.cmdCancel.Size = new System.Drawing.Size(75, 27);
+			this.cmdCancel.TabIndex = 8;
+			this.cmdCancel.Tag = "String_Cancel";
+			this.cmdCancel.Text = "Cancel";
+			this.cmdCancel.UseVisualStyleBackColor = true;
+			this.cmdCancel.Click += new System.EventHandler(this.cmdCancel_Click);
+			//
+			// frmCloudMetadata
+			//
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.ClientSize = new System.Drawing.Size(454, 234);
+			this.Controls.Add(this.cmdCancel);
+			this.Controls.Add(this.cmdOK);
+			this.Controls.Add(this.txtImageUrl);
+			this.Controls.Add(this.lblImageUrl);
+			this.Controls.Add(this.txtDescription);
+			this.Controls.Add(this.lblDescription);
+			this.Controls.Add(this.txtDisplayName);
+			this.Controls.Add(this.lblDisplayName);
+			this.Controls.Add(this.lblNote);
+			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedDialog;
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "frmCloudMetadata";
+			this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+			this.Tag = "Title_CloudMetadata";
+			this.Text = "Cloud Document Metadata";
+			this.Load += new System.EventHandler(this.frmCloudMetadata_Load);
+			this.ResumeLayout(false);
+			this.PerformLayout();
+		}
+
+		private System.Windows.Forms.Label lblNote;
+		private System.Windows.Forms.Label lblDisplayName;
+		private System.Windows.Forms.TextBox txtDisplayName;
+		private System.Windows.Forms.Label lblDescription;
+		private System.Windows.Forms.TextBox txtDescription;
+		private System.Windows.Forms.Label lblImageUrl;
+		private System.Windows.Forms.TextBox txtImageUrl;
+		private System.Windows.Forms.Button cmdOK;
+		private System.Windows.Forms.Button cmdCancel;
+	}
+}

--- a/Chummer/code/frmCloudMetadata.cs
+++ b/Chummer/code/frmCloudMetadata.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Windows.Forms;
+
+namespace Chummer
+{
+	/// <summary>
+	/// Edits a character's RunnersPoint cloud document metadata (displayName/description/imageUrl, per
+	/// the API's Document.metadata schema). Local-only for now - the API has no way for a client to
+	/// submit metadata at all (create/pushRevision take only raw file bytes), so nothing here is sent
+	/// anywhere yet. Staged for when/if the server adds that; stored in the character file either way so
+	/// the values aren't lost in the meantime.
+	/// </summary>
+	public partial class frmCloudMetadata : Form
+	{
+		private readonly Character _objCharacter;
+
+		public frmCloudMetadata(Character objCharacter)
+		{
+			_objCharacter = objCharacter;
+			InitializeComponent();
+			LanguageManager.Instance.Load(GlobalOptions.Instance.Language, this);
+		}
+
+		private void frmCloudMetadata_Load(object sender, EventArgs e)
+		{
+			txtDisplayName.Text = _objCharacter.CloudMetadataDisplayName;
+			txtDescription.Text = _objCharacter.CloudMetadataDescription;
+			txtImageUrl.Text = _objCharacter.CloudMetadataImageUrl;
+		}
+
+		private void cmdOK_Click(object sender, EventArgs e)
+		{
+			_objCharacter.CloudMetadataDisplayName = txtDisplayName.Text.Trim();
+			_objCharacter.CloudMetadataDescription = txtDescription.Text.Trim();
+			_objCharacter.CloudMetadataImageUrl = txtImageUrl.Text.Trim();
+
+			if (!string.IsNullOrEmpty(_objCharacter.FileName))
+				_objCharacter.Save();
+
+			DialogResult = DialogResult.OK;
+			Close();
+		}
+
+		private void cmdCancel_Click(object sender, EventArgs e)
+		{
+			DialogResult = DialogResult.Cancel;
+			Close();
+		}
+	}
+}

--- a/Chummer/code/frmCreate.cs
+++ b/Chummer/code/frmCreate.cs
@@ -16,6 +16,14 @@ namespace Chummer
 		private Character _objCharacter;
 		private MainController _objController;
 
+		/// <summary>
+		/// The Character open in this window.
+		/// </summary>
+		public Character CharacterObject
+		{
+			get { return _objCharacter; }
+		}
+
 		private CharacterOptions _objOptions;
 		private CommonFunctions _objFunctions;
 		private bool _blnSkipRefresh = false;
@@ -17928,6 +17936,9 @@ namespace Chummer
 			if (saveFileDialog.ShowDialog(this) == DialogResult.OK)
 			{
 				string strFileName = saveFileDialog.FileName;
+				// A Save As copy is an independent character - it should get its own cloud document
+				// on next push, not silently push new revisions onto the original's document.
+				_objCharacter.CloudDocumentId = "";
 				_objCharacter.FileName = strFileName;
 				_objCharacter.Save();
 				_blnIsDirty = false;

--- a/Chummer/code/frmMain.Designer.cs
+++ b/Chummer/code/frmMain.Designer.cs
@@ -67,6 +67,7 @@
 			this.toolStripSeparator5 = new System.Windows.Forms.ToolStripSeparator();
 			this.optionsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.mnuToolsUpdate = new System.Windows.Forms.ToolStripMenuItem();
+			this.mnuToolsCloudDocuments = new System.Windows.Forms.ToolStripMenuItem();
 			this.windowsMenu = new System.Windows.Forms.ToolStripMenuItem();
 			this.newWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.closeAllToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -432,6 +433,7 @@
             this.mnuToolsDiceRoller,
             this.toolStripSeparator5,
             this.optionsToolStripMenuItem,
+            this.mnuToolsCloudDocuments,
             this.mnuToolsUpdate});
 			this.toolsMenu.Name = "toolsMenu";
 			this.toolsMenu.Size = new System.Drawing.Size(48, 20);
@@ -470,6 +472,14 @@
 			this.mnuToolsUpdate.Tag = "Menu_Main_Update";
 			this.mnuToolsUpdate.Text = "Check for Updates";
 			this.mnuToolsUpdate.Click += new System.EventHandler(this.mnuToolsUpdate_Click);
+			//
+			// mnuToolsCloudDocuments
+			//
+			this.mnuToolsCloudDocuments.Name = "mnuToolsCloudDocuments";
+			this.mnuToolsCloudDocuments.Size = new System.Drawing.Size(171, 22);
+			this.mnuToolsCloudDocuments.Tag = "Menu_Main_CloudDocuments";
+			this.mnuToolsCloudDocuments.Text = "Cloud Documents...";
+			this.mnuToolsCloudDocuments.Click += new System.EventHandler(this.mnuToolsCloudDocuments_Click);
 			//
 			// windowsMenu
 			// 
@@ -715,6 +725,7 @@
 		private System.Windows.Forms.ToolStripButton helpToolStripButton;
 		private System.Windows.Forms.ToolTip toolTip;
 		private System.Windows.Forms.ToolStripMenuItem mnuToolsUpdate;
+		private System.Windows.Forms.ToolStripMenuItem mnuToolsCloudDocuments;
 		private System.Windows.Forms.ToolStripButton tsbSave;
 		private System.Windows.Forms.ToolStripMenuItem mnuHelpRevisionHistory;
 		private System.Windows.Forms.ToolStripMenuItem mnuNewCritter;

--- a/Chummer/code/frmMain.cs
+++ b/Chummer/code/frmMain.cs
@@ -125,6 +125,21 @@ namespace Chummer
 			frmUpdateApp.ShowDialog(this);
 		}
 
+		private void mnuToolsCloudDocuments_Click(object sender, EventArgs e)
+		{
+			Character objActiveCharacter = null;
+			if (this.ActiveMdiChild != null)
+			{
+				if (this.ActiveMdiChild.GetType() == typeof(frmCareer))
+					objActiveCharacter = ((frmCareer)this.ActiveMdiChild).CharacterObject;
+				else if (this.ActiveMdiChild.GetType() == typeof(frmCreate))
+					objActiveCharacter = ((frmCreate)this.ActiveMdiChild).CharacterObject;
+			}
+
+			frmCloudDocuments frmCloud = new frmCloudDocuments(objActiveCharacter);
+			frmCloud.ShowDialog(this);
+		}
+
 		private void aboutToolStripMenuItem_Click(object sender, EventArgs e)
 		{
 			frmAbout frmShowAbout = new frmAbout();

--- a/Chummer/code/frmOptions.Designer.cs
+++ b/Chummer/code/frmOptions.Designer.cs
@@ -114,6 +114,8 @@
 			this.cmdPDFAppPath = new System.Windows.Forms.Button();
 			this.txtPDFAppPath = new System.Windows.Forms.TextBox();
 			this.lblPDFAppPath = new System.Windows.Forms.Label();
+			this.txtCloudApiBaseUrl = new System.Windows.Forms.TextBox();
+			this.lblCloudApiBaseUrl = new System.Windows.Forms.Label();
 			this.lblXSLT = new System.Windows.Forms.Label();
 			this.cboXSLT = new System.Windows.Forms.ComboBox();
 			this.lblLanguage = new System.Windows.Forms.Label();
@@ -1079,6 +1081,8 @@
 			this.tabGlobal.Controls.Add(this.cmdPDFAppPath);
 			this.tabGlobal.Controls.Add(this.txtPDFAppPath);
 			this.tabGlobal.Controls.Add(this.lblPDFAppPath);
+			this.tabGlobal.Controls.Add(this.txtCloudApiBaseUrl);
+			this.tabGlobal.Controls.Add(this.lblCloudApiBaseUrl);
 			this.tabGlobal.Controls.Add(this.lblXSLT);
 			this.tabGlobal.Controls.Add(this.cboXSLT);
 			this.tabGlobal.Controls.Add(this.lblLanguage);
@@ -1230,7 +1234,24 @@
 			this.lblPDFAppPath.TabIndex = 9;
 			this.lblPDFAppPath.Tag = "Label_Options_PDFApplicationPath";
 			this.lblPDFAppPath.Text = "Location of PDF application:";
-			// 
+			//
+			// txtCloudApiBaseUrl
+			//
+			this.txtCloudApiBaseUrl.Location = new System.Drawing.Point(153, 397);
+			this.txtCloudApiBaseUrl.Name = "txtCloudApiBaseUrl";
+			this.txtCloudApiBaseUrl.Size = new System.Drawing.Size(281, 20);
+			this.txtCloudApiBaseUrl.TabIndex = 17;
+			//
+			// lblCloudApiBaseUrl
+			//
+			this.lblCloudApiBaseUrl.AutoSize = true;
+			this.lblCloudApiBaseUrl.Location = new System.Drawing.Point(6, 400);
+			this.lblCloudApiBaseUrl.Name = "lblCloudApiBaseUrl";
+			this.lblCloudApiBaseUrl.Size = new System.Drawing.Size(126, 13);
+			this.lblCloudApiBaseUrl.TabIndex = 16;
+			this.lblCloudApiBaseUrl.Tag = "Label_Options_CloudApiBaseUrl";
+			this.lblCloudApiBaseUrl.Text = "Cloud Documents server:";
+			//
 			// lblXSLT
 			// 
 			this.lblXSLT.AutoSize = true;
@@ -3500,6 +3521,8 @@
 		private System.Windows.Forms.Button cmdPDFAppPath;
 		private System.Windows.Forms.TextBox txtPDFAppPath;
 		private System.Windows.Forms.Label lblPDFAppPath;
+		private System.Windows.Forms.TextBox txtCloudApiBaseUrl;
+		private System.Windows.Forms.Label lblCloudApiBaseUrl;
 		private System.Windows.Forms.NumericUpDown nudPDFOffset;
 		private System.Windows.Forms.Label lblPDFOffset;
 		private System.Windows.Forms.Button cmdPDFLocation;

--- a/Chummer/code/frmOptions.cs
+++ b/Chummer/code/frmOptions.cs
@@ -172,6 +172,7 @@ namespace Chummer
 			chkPrintToFileFirst.Checked = blnPrintToFileFirst;
 
 			txtPDFAppPath.Text = GlobalOptions.Instance.PDFAppPath;
+			txtCloudApiBaseUrl.Text = GlobalOptions.Instance.CloudApiBaseUrl;
 
 			// Populate the Language List.
 			string strPath = Path.Combine(Application.StartupPath, "lang");
@@ -761,6 +762,7 @@ namespace Chummer
 			txtPDFAppPath.Left = lblPDFAppPath.Left + lblPDFAppPath.Width + 6;
 			cmdPDFAppPath.Left = txtPDFAppPath.Left + txtPDFAppPath.Width + 6;
 			cmdPDFTest.Left = nudPDFOffset.Left + nudPDFOffset.Width + 6;
+			txtCloudApiBaseUrl.Left = lblCloudApiBaseUrl.Left + lblCloudApiBaseUrl.Width + 6;
 
 			intWidth = Math.Max(lblPDFLocation.Width, lblPDFOffset.Width);
 			txtPDFLocation.Left = lblPDFLocation.Left + intWidth + 6;
@@ -1727,6 +1729,7 @@ namespace Chummer
 			GlobalOptions.Instance.DatesIncludeTime = chkDatesIncludeTime.Checked;
 			GlobalOptions.Instance.PrintToFileFirst = chkPrintToFileFirst.Checked;
 			GlobalOptions.Instance.PDFAppPath = txtPDFAppPath.Text;
+			GlobalOptions.Instance.CloudApiBaseUrl = txtCloudApiBaseUrl.Text;
 			GlobalOptions.Instance.PDFArgumentStyle = cboPDFArgumentStyle.SelectedValue.ToString();
 			SettingsRegistryKey objRegistry = SettingsStore.CurrentUser.CreateSubKey("Software\\Chummer");
 			objRegistry.SetValue("autoupdate", chkAutomaticUpdate.Checked.ToString());
@@ -1740,6 +1743,7 @@ namespace Chummer
 			objRegistry.SetValue("printtofilefirst", chkPrintToFileFirst.Checked.ToString());
 
 			objRegistry.SetValue("pdfapppath", txtPDFAppPath.Text);
+			objRegistry.SetValue("cloudapibaseurl", txtCloudApiBaseUrl.Text);
 
 			// Save the SourcebookInfo.
 			SettingsRegistryKey objSourceRegistry = SettingsStore.CurrentUser.CreateSubKey("Software\\Chummer\\Sourcebook");

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -544,6 +544,90 @@
 			<text>Nach Updates suchen</text>
 		</string>
 		<string>
+			<key>Menu_Main_CloudDocuments</key>
+			<text>Cloud-Dokumente...</text>
+		</string>
+		<string>
+			<key>Title_CloudDocuments</key>
+			<text>Cloud-Dokumente</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Login</key>
+			<text>Anmelden</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Logout</key>
+			<text>Abmelden</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Refresh</key>
+			<text>Aktualisieren</text>
+		</string>
+		<string>
+			<key>Button_Cloud_PushCurrent</key>
+			<text>Aktuellen Charakter hochladen</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Download</key>
+			<text>Auswahl herunterladen</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Archive</key>
+			<text>Auswahl archivieren</text>
+		</string>
+		<string>
+			<key>String_Cloud_NotLoggedIn</key>
+			<text>Nicht angemeldet. Klicken Sie auf Anmelden, um Ihr RunnersPoint-Konto zu verbinden.</text>
+		</string>
+		<string>
+			<key>String_Cloud_LoggingIn</key>
+			<text>Browser wird zur Anmeldung geöffnet...</text>
+		</string>
+		<string>
+			<key>String_Cloud_LoginFailed</key>
+			<text>Anmeldung fehlgeschlagen: {0}</text>
+		</string>
+		<string>
+			<key>String_Cloud_Refreshing</key>
+			<text>Wird aktualisiert...</text>
+		</string>
+		<string>
+			<key>String_Cloud_Ready</key>
+			<text>Bereit.</text>
+		</string>
+		<string>
+			<key>String_Cloud_NoGameProfile</key>
+			<text>Es wurde kein passendes Shadowrun-4th-Edition-Spielprofil auf dem Server gefunden.</text>
+		</string>
+		<string>
+			<key>String_Cloud_Pushing</key>
+			<text>Charakter wird hochgeladen...</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushAccepted</key>
+			<text>Upload akzeptiert - die Validierung läuft im Hintergrund.</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushStale</key>
+			<text>Ihre lokale Kopie ist veraltet gegenüber der Cloud-Version. Laden Sie die aktuelle Version herunter, bevor Sie erneut hochladen.</text>
+		</string>
+		<string>
+			<key>String_Cloud_Downloading</key>
+			<text>Wird heruntergeladen...</text>
+		</string>
+		<string>
+			<key>String_Cloud_Error</key>
+			<text>Fehler: {0}</text>
+		</string>
+		<string>
+			<key>Message_Cloud_ConfirmArchive</key>
+			<text>"{0}" in der Cloud archivieren? Ihre lokale Datei wird dadurch nicht gelöscht.</text>
+		</string>
+		<string>
+			<key>MessageTitle_Cloud_ConfirmArchive</key>
+			<text>Dokument archivieren</text>
+		</string>
+		<string>
 			<key>Menu_Main_Omae</key>
 			<text>Omae</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-954</version>
+	<version>-955</version>
 	<name>Deutsch (DE)</name>
 	<strings>
 		<string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -620,6 +620,14 @@
 			<text>Es wurde kein passendes Shadowrun-4th-Edition-Spielprofil auf dem Server gefunden.</text>
 		</string>
 		<string>
+			<key>String_Cloud_UnsupportedDocumentType</key>
+			<text>Der Server unterstützt Charakterdokumente nicht in einem Format, das Chummer versteht.</text>
+		</string>
+		<string>
+			<key>String_Cloud_AuthExpired</key>
+			<text>Ihre RunnersPoint-Anmeldung ist abgelaufen oder wurde widerrufen. Bitte melden Sie sich erneut an oder fügen Sie ein neues API-Token ein.</text>
+		</string>
+		<string>
 			<key>String_Cloud_Pushing</key>
 			<text>Charakter wird hochgeladen...</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -652,6 +652,14 @@
 			<text>Dokument archivieren</text>
 		</string>
 		<string>
+			<key>Message_Cloud_ConfirmPushShared</key>
+			<text>Inhalt Ihres aktuellen Charakters zu "{0}" senden? Dies überschreibt das geteilte Dokument für alle, mit denen es geteilt wurde, nicht nur für Sie.</text>
+		</string>
+		<string>
+			<key>MessageTitle_Cloud_ConfirmPushShared</key>
+			<text>Aktualisierung an geteiltes Dokument senden</text>
+		</string>
+		<string>
 			<key>Menu_Main_Omae</key>
 			<text>Omae</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -588,6 +588,30 @@
 			<text>Aktualisierung für Auswahl senden</text>
 		</string>
 		<string>
+			<key>Button_Cloud_EditMetadata</key>
+			<text>Metadaten bearbeiten...</text>
+		</string>
+		<string>
+			<key>Title_CloudMetadata</key>
+			<text>Cloud-Dokument-Metadaten</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_Note</key>
+			<text>Wird noch nicht an RunnersPoint gesendet - der Server kann dies noch nicht von einem Client entgegennehmen. Wird lokal gespeichert, damit es nicht verloren geht, sobald es möglich ist.</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_DisplayName</key>
+			<text>Anzeigename:</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_Description</key>
+			<text>Beschreibung:</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_ImageUrl</key>
+			<text>Bild-URL:</text>
+		</string>
+		<string>
 			<key>Radio_Cloud_MyDocuments</key>
 			<text>Meine Dokumente</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -640,6 +640,10 @@
 			<text>Es wurde kein passendes Shadowrun-4th-Edition-Spielprofil auf dem Server gefunden.</text>
 		</string>
 		<string>
+			<key>String_Cloud_ServerUnreachable</key>
+			<text>Der RunnersPoint-Server konnte nicht erreicht werden. Überprüfen Sie Ihre Verbindung und die Serveradresse in den Optionen und versuchen Sie es erneut.</text>
+		</string>
+		<string>
 			<key>String_Cloud_UnsupportedDocumentType</key>
 			<text>Der Server unterstützt Charakterdokumente nicht in einem Format, das Chummer versteht.</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -556,6 +556,14 @@
 			<text>Anmelden</text>
 		</string>
 		<string>
+			<key>Label_Cloud_ApiToken</key>
+			<text>API-Token:</text>
+		</string>
+		<string>
+			<key>Button_Cloud_UseApiToken</key>
+			<text>Token verwenden</text>
+		</string>
+		<string>
 			<key>Button_Cloud_Logout</key>
 			<text>Abmelden</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -6701,6 +6701,10 @@
 			<text>Pfad zur PDF-Betrachter:</text>
 		</string>
 		<string>
+			<key>Label_Options_CloudApiBaseUrl</key>
+			<text>Cloud-Dokumente-Server:</text>
+		</string>
+		<string>
 			<key>Label_Options_PDFLocation</key>
 			<text>Pfad zur PDF-Datei:</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -576,6 +576,18 @@
 			<text>Auswahl archivieren</text>
 		</string>
 		<string>
+			<key>Button_Cloud_PushShared</key>
+			<text>Aktualisierung für Auswahl senden</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_MyDocuments</key>
+			<text>Meine Dokumente</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_SharedWithMe</key>
+			<text>Mit mir geteilt</text>
+		</string>
+		<string>
 			<key>String_Cloud_NotLoggedIn</key>
 			<text>Nicht angemeldet. Klicken Sie auf Anmelden, um Ihr RunnersPoint-Konto zu verbinden.</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -644,6 +644,10 @@
 			<text>Der vorherige Upload wird noch validiert. Versuchen Sie es gleich noch einmal.</text>
 		</string>
 		<string>
+			<key>String_Cloud_NotSavedLocally</key>
+			<text>Speichern Sie diesen Charakter lokal (Datei > Speichern), bevor Sie ihn in die Cloud hochladen.</text>
+		</string>
+		<string>
 			<key>String_Cloud_PushIdempotencyConflict</key>
 			<text>Eine vorherige Anfrage mit derselben Anforderung wird noch verarbeitet. Warten Sie einen Moment und versuchen Sie es erneut.</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -612,6 +612,18 @@
 			<text>Ihre lokale Kopie ist veraltet gegenüber der Cloud-Version. Laden Sie die aktuelle Version herunter, bevor Sie erneut hochladen.</text>
 		</string>
 		<string>
+			<key>String_Cloud_PushInFlight</key>
+			<text>Der vorherige Upload wird noch validiert. Versuchen Sie es gleich noch einmal.</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushIdempotencyConflict</key>
+			<text>Eine vorherige Anfrage mit derselben Anforderung wird noch verarbeitet. Warten Sie einen Moment und versuchen Sie es erneut.</text>
+		</string>
+		<string>
+			<key>String_Cloud_NotDownloadable</key>
+			<text>Dieses Dokument kann derzeit nicht heruntergeladen werden (Status: {0}).</text>
+		</string>
+		<string>
 			<key>String_Cloud_Downloading</key>
 			<text>Wird heruntergeladen...</text>
 		</string>

--- a/Chummer/data/lang/de.xml
+++ b/Chummer/data/lang/de.xml
@@ -596,6 +596,26 @@
 			<text>Mit mir geteilt</text>
 		</string>
 		<string>
+			<key>Radio_Cloud_AuthApiToken</key>
+			<text>API-Token verwenden</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_AuthOAuth</key>
+			<text>OAuth-Anmeldung verwenden</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_NotConnected</key>
+			<text>Nicht verbunden.</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_ApiToken</key>
+			<text>Verbunden über API-Token.</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_OAuth</key>
+			<text>Verbunden über OAuth-Anmeldung.</text>
+		</string>
+		<string>
 			<key>String_Cloud_NotLoggedIn</key>
 			<text>Nicht angemeldet. Klicken Sie auf Anmelden, um Ihr RunnersPoint-Konto zu verbinden.</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -649,6 +649,30 @@
 			<text>Push Update to Selected</text>
 		</string>
 		<string>
+			<key>Button_Cloud_EditMetadata</key>
+			<text>Edit Metadata...</text>
+		</string>
+		<string>
+			<key>Title_CloudMetadata</key>
+			<text>Cloud Document Metadata</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_Note</key>
+			<text>Not sent to RunnersPoint yet - the server has no way to accept this from a client. Stored locally so it isn't lost once it can.</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_DisplayName</key>
+			<text>Display Name:</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_Description</key>
+			<text>Description:</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_ImageUrl</key>
+			<text>Image URL:</text>
+		</string>
+		<string>
 			<key>Radio_Cloud_MyDocuments</key>
 			<text>My Documents</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -673,6 +673,18 @@
 			<text>Your local copy is out of date with the cloud version. Download the latest version before pushing again.</text>
 		</string>
 		<string>
+			<key>String_Cloud_PushInFlight</key>
+			<text>The previous push is still being validated. Try again shortly.</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushIdempotencyConflict</key>
+			<text>A previous push with the same request is still being processed. Wait a moment and try again.</text>
+		</string>
+		<string>
+			<key>String_Cloud_NotDownloadable</key>
+			<text>This document can't be downloaded right now (state: {0}).</text>
+		</string>
+		<string>
 			<key>String_Cloud_Downloading</key>
 			<text>Downloading...</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -701,6 +701,10 @@
 			<text>No matching Shadowrun 4th Edition game profile was found on the server.</text>
 		</string>
 		<string>
+			<key>String_Cloud_ServerUnreachable</key>
+			<text>Could not reach the RunnersPoint server. Check your connection and the server address in Options, then try again.</text>
+		</string>
+		<string>
 			<key>String_Cloud_UnsupportedDocumentType</key>
 			<text>The server doesn't advertise support for character documents in a format Chummer understands.</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -617,6 +617,14 @@
 			<text>Log In</text>
 		</string>
 		<string>
+			<key>Label_Cloud_ApiToken</key>
+			<text>API Token:</text>
+		</string>
+		<string>
+			<key>Button_Cloud_UseApiToken</key>
+			<text>Use Token</text>
+		</string>
+		<string>
 			<key>Button_Cloud_Logout</key>
 			<text>Log Out</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -713,6 +713,14 @@
 			<text>Archive Document</text>
 		</string>
 		<string>
+			<key>Message_Cloud_ConfirmPushShared</key>
+			<text>Push your current character's content to "{0}"? This overwrites the shared document for everyone it's shared with, not just you.</text>
+		</string>
+		<string>
+			<key>MessageTitle_Cloud_ConfirmPushShared</key>
+			<text>Push Update to Shared Document</text>
+		</string>
+		<string>
 			<key>Menu_Main_Omae</key>
 			<text>Omae</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -605,6 +605,90 @@
 			<text>Check for Updates</text>
 		</string>
 		<string>
+			<key>Menu_Main_CloudDocuments</key>
+			<text>Cloud Documents...</text>
+		</string>
+		<string>
+			<key>Title_CloudDocuments</key>
+			<text>Cloud Documents</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Login</key>
+			<text>Log In</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Logout</key>
+			<text>Log Out</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Refresh</key>
+			<text>Refresh</text>
+		</string>
+		<string>
+			<key>Button_Cloud_PushCurrent</key>
+			<text>Push Current Character</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Download</key>
+			<text>Download Selected</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Archive</key>
+			<text>Archive Selected</text>
+		</string>
+		<string>
+			<key>String_Cloud_NotLoggedIn</key>
+			<text>Not logged in. Click Log In to connect your RunnersPoint account.</text>
+		</string>
+		<string>
+			<key>String_Cloud_LoggingIn</key>
+			<text>Opening browser to log in...</text>
+		</string>
+		<string>
+			<key>String_Cloud_LoginFailed</key>
+			<text>Login failed: {0}</text>
+		</string>
+		<string>
+			<key>String_Cloud_Refreshing</key>
+			<text>Refreshing...</text>
+		</string>
+		<string>
+			<key>String_Cloud_Ready</key>
+			<text>Ready.</text>
+		</string>
+		<string>
+			<key>String_Cloud_NoGameProfile</key>
+			<text>No matching Shadowrun 4th Edition game profile was found on the server.</text>
+		</string>
+		<string>
+			<key>String_Cloud_Pushing</key>
+			<text>Pushing character...</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushAccepted</key>
+			<text>Upload accepted - validation is running in the background.</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushStale</key>
+			<text>Your local copy is out of date with the cloud version. Download the latest version before pushing again.</text>
+		</string>
+		<string>
+			<key>String_Cloud_Downloading</key>
+			<text>Downloading...</text>
+		</string>
+		<string>
+			<key>String_Cloud_Error</key>
+			<text>Error: {0}</text>
+		</string>
+		<string>
+			<key>Message_Cloud_ConfirmArchive</key>
+			<text>Archive "{0}" in the cloud? This does not delete your local file.</text>
+		</string>
+		<string>
+			<key>MessageTitle_Cloud_ConfirmArchive</key>
+			<text>Archive Document</text>
+		</string>
+		<string>
 			<key>Menu_Main_Omae</key>
 			<text>Omae</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -705,6 +705,10 @@
 			<text>The previous push is still being validated. Try again shortly.</text>
 		</string>
 		<string>
+			<key>String_Cloud_NotSavedLocally</key>
+			<text>Save this character locally (File > Save) before pushing it to the cloud.</text>
+		</string>
+		<string>
 			<key>String_Cloud_PushIdempotencyConflict</key>
 			<text>A previous push with the same request is still being processed. Wait a moment and try again.</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -637,6 +637,18 @@
 			<text>Archive Selected</text>
 		</string>
 		<string>
+			<key>Button_Cloud_PushShared</key>
+			<text>Push Update to Selected</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_MyDocuments</key>
+			<text>My Documents</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_SharedWithMe</key>
+			<text>Shared With Me</text>
+		</string>
+		<string>
 			<key>String_Cloud_NotLoggedIn</key>
 			<text>Not logged in. Click Log In to connect your RunnersPoint account.</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-915</version>
+	<version>-916</version>
 	<name>English (US)</name>
 	<strings>
 		<!-- Common Strings -->

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -5611,6 +5611,10 @@ Only one attribute may be at its Maximum value during character creation.</text>
 			<text>Location of PDF application:</text>
 		</string>
 		<string>
+			<key>Label_Options_CloudApiBaseUrl</key>
+			<text>Cloud Documents server:</text>
+		</string>
+		<string>
 			<key>Label_Options_PDFLocation</key>
 			<text>PDF Location:</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -657,6 +657,26 @@
 			<text>Shared With Me</text>
 		</string>
 		<string>
+			<key>Radio_Cloud_AuthApiToken</key>
+			<text>Use API Token</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_AuthOAuth</key>
+			<text>Use OAuth Login</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_NotConnected</key>
+			<text>Not connected.</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_ApiToken</key>
+			<text>Connected via API token.</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_OAuth</key>
+			<text>Connected via OAuth login.</text>
+		</string>
+		<string>
 			<key>String_Cloud_NotLoggedIn</key>
 			<text>Not logged in. Click Log In to connect your RunnersPoint account.</text>
 		</string>

--- a/Chummer/data/lang/en-us.xml
+++ b/Chummer/data/lang/en-us.xml
@@ -681,6 +681,14 @@
 			<text>No matching Shadowrun 4th Edition game profile was found on the server.</text>
 		</string>
 		<string>
+			<key>String_Cloud_UnsupportedDocumentType</key>
+			<text>The server doesn't advertise support for character documents in a format Chummer understands.</text>
+		</string>
+		<string>
+			<key>String_Cloud_AuthExpired</key>
+			<text>Your RunnersPoint login has expired or been revoked. Please log in again or paste a new API token.</text>
+		</string>
+		<string>
 			<key>String_Cloud_Pushing</key>
 			<text>Pushing character...</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -697,6 +697,10 @@
 			<text>Aucun profil de jeu Shadowrun 4e édition correspondant n'a été trouvé sur le serveur.</text>
 		</string>
 		<string>
+			<key>String_Cloud_ServerUnreachable</key>
+			<text>Impossible de joindre le serveur RunnersPoint. Vérifiez votre connexion et l'adresse du serveur dans les options, puis réessayez.</text>
+		</string>
+		<string>
 			<key>String_Cloud_UnsupportedDocumentType</key>
 			<text>Le serveur n'annonce pas de prise en charge des documents de personnage dans un format que Chummer comprend.</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -601,6 +601,90 @@
 			<text>&amp;Mises à jour</text>
 		</string>
 		<string>
+			<key>Menu_Main_CloudDocuments</key>
+			<text>Documents en ligne...</text>
+		</string>
+		<string>
+			<key>Title_CloudDocuments</key>
+			<text>Documents en ligne</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Login</key>
+			<text>Connexion</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Logout</key>
+			<text>Déconnexion</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Refresh</key>
+			<text>Actualiser</text>
+		</string>
+		<string>
+			<key>Button_Cloud_PushCurrent</key>
+			<text>Envoyer le personnage actuel</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Download</key>
+			<text>Télécharger la sélection</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Archive</key>
+			<text>Archiver la sélection</text>
+		</string>
+		<string>
+			<key>String_Cloud_NotLoggedIn</key>
+			<text>Non connecté. Cliquez sur Connexion pour lier votre compte RunnersPoint.</text>
+		</string>
+		<string>
+			<key>String_Cloud_LoggingIn</key>
+			<text>Ouverture du navigateur pour la connexion...</text>
+		</string>
+		<string>
+			<key>String_Cloud_LoginFailed</key>
+			<text>Échec de la connexion : {0}</text>
+		</string>
+		<string>
+			<key>String_Cloud_Refreshing</key>
+			<text>Actualisation...</text>
+		</string>
+		<string>
+			<key>String_Cloud_Ready</key>
+			<text>Prêt.</text>
+		</string>
+		<string>
+			<key>String_Cloud_NoGameProfile</key>
+			<text>Aucun profil de jeu Shadowrun 4e édition correspondant n'a été trouvé sur le serveur.</text>
+		</string>
+		<string>
+			<key>String_Cloud_Pushing</key>
+			<text>Envoi du personnage...</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushAccepted</key>
+			<text>Envoi accepté - la validation s'exécute en arrière-plan.</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushStale</key>
+			<text>Votre copie locale n'est pas à jour par rapport à la version en ligne. Téléchargez la dernière version avant de réessayer.</text>
+		</string>
+		<string>
+			<key>String_Cloud_Downloading</key>
+			<text>Téléchargement...</text>
+		</string>
+		<string>
+			<key>String_Cloud_Error</key>
+			<text>Erreur : {0}</text>
+		</string>
+		<string>
+			<key>Message_Cloud_ConfirmArchive</key>
+			<text>Archiver « {0} » en ligne ? Votre fichier local ne sera pas supprimé.</text>
+		</string>
+		<string>
+			<key>MessageTitle_Cloud_ConfirmArchive</key>
+			<text>Archiver le document</text>
+		</string>
+		<string>
 			<key>Menu_Main_Omae</key>
 			<text>Omae</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -5567,6 +5567,10 @@ Un saul attribut peut atteindre sa valeur maximum durant la création de personn
 			<text>Emplacement de l'application PDF:</text>
 		</string>
 		<string>
+			<key>Label_Options_CloudApiBaseUrl</key>
+			<text>Serveur Cloud Documents:</text>
+		</string>
+		<string>
 			<key>Label_Options_PDFLocation</key>
 			<text>Emplacement du fichier PDF:</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -709,6 +709,14 @@
 			<text>Archiver le document</text>
 		</string>
 		<string>
+			<key>Message_Cloud_ConfirmPushShared</key>
+			<text>Envoyer le contenu de votre personnage actuel vers « {0} » ? Cela écrase le document partagé pour tous ceux avec qui il est partagé, pas seulement pour vous.</text>
+		</string>
+		<string>
+			<key>MessageTitle_Cloud_ConfirmPushShared</key>
+			<text>Envoyer la mise à jour au document partagé</text>
+		</string>
+		<string>
 			<key>Menu_Main_Omae</key>
 			<text>Omae</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -633,6 +633,18 @@
 			<text>Archiver la sélection</text>
 		</string>
 		<string>
+			<key>Button_Cloud_PushShared</key>
+			<text>Envoyer la mise à jour de la sélection</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_MyDocuments</key>
+			<text>Mes documents</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_SharedWithMe</key>
+			<text>Partagés avec moi</text>
+		</string>
+		<string>
 			<key>String_Cloud_NotLoggedIn</key>
 			<text>Non connecté. Cliquez sur Connexion pour lier votre compte RunnersPoint.</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -613,6 +613,14 @@
 			<text>Connexion</text>
 		</string>
 		<string>
+			<key>Label_Cloud_ApiToken</key>
+			<text>Jeton API :</text>
+		</string>
+		<string>
+			<key>Button_Cloud_UseApiToken</key>
+			<text>Utiliser le jeton</text>
+		</string>
+		<string>
 			<key>Button_Cloud_Logout</key>
 			<text>Déconnexion</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <chummer>
-	<version>-959</version>
+	<version>-960</version>
 	<name>Français</name>
 	<strings>
 		<!-- Common Strings -->

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -677,6 +677,14 @@
 			<text>Aucun profil de jeu Shadowrun 4e édition correspondant n'a été trouvé sur le serveur.</text>
 		</string>
 		<string>
+			<key>String_Cloud_UnsupportedDocumentType</key>
+			<text>Le serveur n'annonce pas de prise en charge des documents de personnage dans un format que Chummer comprend.</text>
+		</string>
+		<string>
+			<key>String_Cloud_AuthExpired</key>
+			<text>Votre connexion RunnersPoint a expiré ou a été révoquée. Veuillez vous reconnecter ou coller un nouveau jeton API.</text>
+		</string>
+		<string>
 			<key>String_Cloud_Pushing</key>
 			<text>Envoi du personnage...</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -701,6 +701,10 @@
 			<text>L'envoi précédent est toujours en cours de validation. Réessayez dans un instant.</text>
 		</string>
 		<string>
+			<key>String_Cloud_NotSavedLocally</key>
+			<text>Enregistrez ce personnage localement (Fichier > Enregistrer) avant de l'envoyer vers le cloud.</text>
+		</string>
+		<string>
 			<key>String_Cloud_PushIdempotencyConflict</key>
 			<text>Une requête précédente identique est toujours en cours de traitement. Patientez un instant puis réessayez.</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -653,6 +653,26 @@
 			<text>Partagés avec moi</text>
 		</string>
 		<string>
+			<key>Radio_Cloud_AuthApiToken</key>
+			<text>Utiliser un jeton API</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_AuthOAuth</key>
+			<text>Utiliser la connexion OAuth</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_NotConnected</key>
+			<text>Non connecté.</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_ApiToken</key>
+			<text>Connecté via un jeton API.</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_OAuth</key>
+			<text>Connecté via une connexion OAuth.</text>
+		</string>
+		<string>
 			<key>String_Cloud_NotLoggedIn</key>
 			<text>Non connecté. Cliquez sur Connexion pour lier votre compte RunnersPoint.</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -645,6 +645,30 @@
 			<text>Envoyer la mise à jour de la sélection</text>
 		</string>
 		<string>
+			<key>Button_Cloud_EditMetadata</key>
+			<text>Modifier les métadonnées...</text>
+		</string>
+		<string>
+			<key>Title_CloudMetadata</key>
+			<text>Métadonnées du document cloud</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_Note</key>
+			<text>Pas encore envoyé à RunnersPoint - le serveur ne peut pas encore recevoir ceci d'un client. Enregistré localement pour ne pas le perdre une fois que ce sera possible.</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_DisplayName</key>
+			<text>Nom d'affichage :</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_Description</key>
+			<text>Description :</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_ImageUrl</key>
+			<text>URL de l'image :</text>
+		</string>
+		<string>
 			<key>Radio_Cloud_MyDocuments</key>
 			<text>Mes documents</text>
 		</string>

--- a/Chummer/data/lang/fr.xml
+++ b/Chummer/data/lang/fr.xml
@@ -669,6 +669,18 @@
 			<text>Votre copie locale n'est pas à jour par rapport à la version en ligne. Téléchargez la dernière version avant de réessayer.</text>
 		</string>
 		<string>
+			<key>String_Cloud_PushInFlight</key>
+			<text>L'envoi précédent est toujours en cours de validation. Réessayez dans un instant.</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushIdempotencyConflict</key>
+			<text>Une requête précédente identique est toujours en cours de traitement. Patientez un instant puis réessayez.</text>
+		</string>
+		<string>
+			<key>String_Cloud_NotDownloadable</key>
+			<text>Ce document ne peut pas être téléchargé pour le moment (état : {0}).</text>
+		</string>
+		<string>
 			<key>String_Cloud_Downloading</key>
 			<text>Téléchargement...</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -683,6 +683,14 @@
 			<text>サーバー上に一致するShadowrun 4th Editionのゲームプロファイルが見つかりませんでした。</text>
 		</string>
 		<string>
+			<key>String_Cloud_UnsupportedDocumentType</key>
+			<text>サーバーは Chummer が理解できる形式でのキャラクタードキュメントのサポートを提供していません。</text>
+		</string>
+		<string>
+			<key>String_Cloud_AuthExpired</key>
+			<text>RunnersPoint へのログインが期限切れになったか、取り消されました。再度ログインするか、新しい API トークンを貼り付けてください。</text>
+		</string>
+		<string>
 			<key>String_Cloud_Pushing</key>
 			<text>キャラクターをアップロード中...</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -607,6 +607,90 @@
 			<text>アップデートを確認</text>
 		</string>
 		<string>
+			<key>Menu_Main_CloudDocuments</key>
+			<text>クラウドドキュメント...</text>
+		</string>
+		<string>
+			<key>Title_CloudDocuments</key>
+			<text>クラウドドキュメント</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Login</key>
+			<text>ログイン</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Logout</key>
+			<text>ログアウト</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Refresh</key>
+			<text>更新</text>
+		</string>
+		<string>
+			<key>Button_Cloud_PushCurrent</key>
+			<text>現在のキャラクターをアップロード</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Download</key>
+			<text>選択項目をダウンロード</text>
+		</string>
+		<string>
+			<key>Button_Cloud_Archive</key>
+			<text>選択項目をアーカイブ</text>
+		</string>
+		<string>
+			<key>String_Cloud_NotLoggedIn</key>
+			<text>ログインしていません。RunnersPointアカウントに接続するには「ログイン」をクリックしてください。</text>
+		</string>
+		<string>
+			<key>String_Cloud_LoggingIn</key>
+			<text>ログイン用のブラウザを開いています...</text>
+		</string>
+		<string>
+			<key>String_Cloud_LoginFailed</key>
+			<text>ログインに失敗しました: {0}</text>
+		</string>
+		<string>
+			<key>String_Cloud_Refreshing</key>
+			<text>更新中...</text>
+		</string>
+		<string>
+			<key>String_Cloud_Ready</key>
+			<text>準備完了。</text>
+		</string>
+		<string>
+			<key>String_Cloud_NoGameProfile</key>
+			<text>サーバー上に一致するShadowrun 4th Editionのゲームプロファイルが見つかりませんでした。</text>
+		</string>
+		<string>
+			<key>String_Cloud_Pushing</key>
+			<text>キャラクターをアップロード中...</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushAccepted</key>
+			<text>アップロードを受け付けました - 検証はバックグラウンドで実行されます。</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushStale</key>
+			<text>ローカルのコピーがクラウド上のバージョンより古くなっています。再度アップロードする前に最新版をダウンロードしてください。</text>
+		</string>
+		<string>
+			<key>String_Cloud_Downloading</key>
+			<text>ダウンロード中...</text>
+		</string>
+		<string>
+			<key>String_Cloud_Error</key>
+			<text>エラー: {0}</text>
+		</string>
+		<string>
+			<key>Message_Cloud_ConfirmArchive</key>
+			<text>「{0}」をクラウドでアーカイブしますか？ ローカルファイルは削除されません。</text>
+		</string>
+		<string>
+			<key>MessageTitle_Cloud_ConfirmArchive</key>
+			<text>ドキュメントをアーカイブ</text>
+		</string>
+		<string>
 			<key>Menu_Main_Omae</key>
 			<text>Omae キャラクター交換</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -703,6 +703,10 @@
 			<text>サーバー上に一致するShadowrun 4th Editionのゲームプロファイルが見つかりませんでした。</text>
 		</string>
 		<string>
+			<key>String_Cloud_ServerUnreachable</key>
+			<text>RunnersPoint サーバーに接続できませんでした。接続と、オプションのサーバーアドレスを確認してから、もう一度お試しください。</text>
+		</string>
+		<string>
 			<key>String_Cloud_UnsupportedDocumentType</key>
 			<text>サーバーは Chummer が理解できる形式でのキャラクタードキュメントのサポートを提供していません。</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -619,6 +619,14 @@
 			<text>ログイン</text>
 		</string>
 		<string>
+			<key>Label_Cloud_ApiToken</key>
+			<text>API トークン:</text>
+		</string>
+		<string>
+			<key>Button_Cloud_UseApiToken</key>
+			<text>トークンを使用</text>
+		</string>
+		<string>
 			<key>Button_Cloud_Logout</key>
 			<text>ログアウト</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -639,6 +639,18 @@
 			<text>選択項目をアーカイブ</text>
 		</string>
 		<string>
+			<key>Button_Cloud_PushShared</key>
+			<text>選択項目に更新をプッシュ</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_MyDocuments</key>
+			<text>マイドキュメント</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_SharedWithMe</key>
+			<text>共有されたドキュメント</text>
+		</string>
+		<string>
 			<key>String_Cloud_NotLoggedIn</key>
 			<text>ログインしていません。RunnersPointアカウントに接続するには「ログイン」をクリックしてください。</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -659,6 +659,26 @@
 			<text>共有されたドキュメント</text>
 		</string>
 		<string>
+			<key>Radio_Cloud_AuthApiToken</key>
+			<text>API トークンを使用</text>
+		</string>
+		<string>
+			<key>Radio_Cloud_AuthOAuth</key>
+			<text>OAuth ログインを使用</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_NotConnected</key>
+			<text>接続されていません。</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_ApiToken</key>
+			<text>API トークンで接続済みです。</text>
+		</string>
+		<string>
+			<key>String_Cloud_ConnectionState_OAuth</key>
+			<text>OAuth ログインで接続済みです。</text>
+		</string>
+		<string>
 			<key>String_Cloud_NotLoggedIn</key>
 			<text>ログインしていません。RunnersPointアカウントに接続するには「ログイン」をクリックしてください。</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -675,6 +675,18 @@
 			<text>ローカルのコピーがクラウド上のバージョンより古くなっています。再度アップロードする前に最新版をダウンロードしてください。</text>
 		</string>
 		<string>
+			<key>String_Cloud_PushInFlight</key>
+			<text>前回のアップロードはまだ検証中です。しばらくしてから再試行してください。</text>
+		</string>
+		<string>
+			<key>String_Cloud_PushIdempotencyConflict</key>
+			<text>同じ内容の以前のリクエストがまだ処理中です。少し待ってから再試行してください。</text>
+		</string>
+		<string>
+			<key>String_Cloud_NotDownloadable</key>
+			<text>このドキュメントは現在ダウンロードできません（状態: {0}）。</text>
+		</string>
+		<string>
 			<key>String_Cloud_Downloading</key>
 			<text>ダウンロード中...</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -707,6 +707,10 @@
 			<text>前回のアップロードはまだ検証中です。しばらくしてから再試行してください。</text>
 		</string>
 		<string>
+			<key>String_Cloud_NotSavedLocally</key>
+			<text>クラウドにプッシュする前に、このキャラクターをローカルに保存してください（ファイル > 保存）。</text>
+		</string>
+		<string>
 			<key>String_Cloud_PushIdempotencyConflict</key>
 			<text>同じ内容の以前のリクエストがまだ処理中です。少し待ってから再試行してください。</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -5608,6 +5608,10 @@
 			<text>PDF アプリケーションの場所:</text>
 		</string>
 		<string>
+			<key>Label_Options_CloudApiBaseUrl</key>
+			<text>クラウドドキュメントサーバー:</text>
+		</string>
+		<string>
 			<key>Label_Options_PDFLocation</key>
 			<text>PDF ファイルの場所:</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -651,6 +651,30 @@
 			<text>選択項目に更新をプッシュ</text>
 		</string>
 		<string>
+			<key>Button_Cloud_EditMetadata</key>
+			<text>メタデータを編集...</text>
+		</string>
+		<string>
+			<key>Title_CloudMetadata</key>
+			<text>クラウドドキュメントのメタデータ</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_Note</key>
+			<text>まだ RunnersPoint には送信されません。サーバーはクライアントからこれを受け取る手段をまだ持っていません。可能になった際に失われないよう、ローカルに保存されます。</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_DisplayName</key>
+			<text>表示名:</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_Description</key>
+			<text>説明:</text>
+		</string>
+		<string>
+			<key>Label_CloudMetadata_ImageUrl</key>
+			<text>画像 URL:</text>
+		</string>
+		<string>
 			<key>Radio_Cloud_MyDocuments</key>
 			<text>マイドキュメント</text>
 		</string>

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -2,7 +2,7 @@
 <!-- この言語ファイルは AhonokoP が作成しました。連絡を取りたいときは"Dumpshock Forum"でAhonokoPにメッセージを送ってください -->
 <!-- Translated by AhonokoP. Contact me at "Dumpshock Forum" -->
 <chummer>
-	<version>-1005</version>
+	<version>-1006</version>
 	<name>日本語 (JP)</name>
 	<strings>
 		<!-- Common Strings -->

--- a/Chummer/data/lang/jp.xml
+++ b/Chummer/data/lang/jp.xml
@@ -715,6 +715,14 @@
 			<text>ドキュメントをアーカイブ</text>
 		</string>
 		<string>
+			<key>Message_Cloud_ConfirmPushShared</key>
+			<text>現在のキャラクターの内容を「{0}」にプッシュしますか？ これはあなただけでなく、共有されている全員の共有ドキュメントを上書きします。</text>
+		</string>
+		<string>
+			<key>MessageTitle_Cloud_ConfirmPushShared</key>
+			<text>共有ドキュメントに更新をプッシュ</text>
+		</string>
+		<string>
 			<key>Menu_Main_Omae</key>
 			<text>Omae キャラクター交換</text>
 		</string>

--- a/Chummer/data/manifestlang.xml
+++ b/Chummer/data/manifestlang.xml
@@ -3,14 +3,14 @@
 	<file>
 		<name>lang/en-us.xml</name>
 		<type>Language File</type>
-		<version>-915</version>
+		<version>-916</version>
 		<description>English (US) language file</description>
 		<notes>- English (US) language file</notes>
 	</file>
 	<file>
 		<name>lang/fr.xml</name>
 		<type>Language File</type>
-		<version>-959</version>
+		<version>-960</version>
 		<description>French language file</description>
 		<notes>- French language file</notes>
 	</file>
@@ -24,7 +24,7 @@
 	<file>
 		<name>lang/de.xml</name>
 		<type>Language File</type>
-		<version>-954</version>
+		<version>-955</version>
 		<description>German language file</description>
 		<notes>German language file</notes>
 	</file>
@@ -45,7 +45,7 @@
 	<file>
 		<name>lang/jp.xml</name>
 		<type>Language File</type>
-		<version>-1005</version>
+		<version>-1006</version>
 		<description>jp language file</description>
 		<notes>jp language file</notes>
 	</file>

--- a/Chummer/packages.config
+++ b/Chummer/packages.config
@@ -5,4 +5,6 @@
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
+  <package id="Serilog" version="4.2.0" targetFramework="net48" />
+  <package id="Serilog.Sinks.File" version="6.0.0" targetFramework="net48" />
 </packages>

--- a/Chummer/packages.config
+++ b/Chummer/packages.config
@@ -5,6 +5,6 @@
   <package id="System.Buffers" version="4.5.1" targetFramework="net48" />
   <package id="System.Runtime.CompilerServices.Unsafe" version="4.5.3" targetFramework="net48" />
   <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net48" />
-  <package id="Serilog" version="4.2.0" targetFramework="net48" />
-  <package id="Serilog.Sinks.File" version="6.0.0" targetFramework="net48" />
+  <package id="Serilog" version="2.12.0" targetFramework="net48" />
+  <package id="Serilog.Sinks.File" version="5.0.0" targetFramework="net48" />
 </packages>

--- a/ChummerGenSR4.sln
+++ b/ChummerGenSR4.sln
@@ -5,16 +5,42 @@ VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chummer", "Chummer\Chummer.csproj", "{95279469-5A3E-42E6-993C-6A403586C86E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chummer.Tests", "Chummer.Tests\Chummer.Tests.csproj", "{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{95279469-5A3E-42E6-993C-6A403586C86E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{95279469-5A3E-42E6-993C-6A403586C86E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{95279469-5A3E-42E6-993C-6A403586C86E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{95279469-5A3E-42E6-993C-6A403586C86E}.Debug|x64.Build.0 = Debug|Any CPU
+		{95279469-5A3E-42E6-993C-6A403586C86E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{95279469-5A3E-42E6-993C-6A403586C86E}.Debug|x86.Build.0 = Debug|Any CPU
 		{95279469-5A3E-42E6-993C-6A403586C86E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{95279469-5A3E-42E6-993C-6A403586C86E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{95279469-5A3E-42E6-993C-6A403586C86E}.Release|x64.ActiveCfg = Release|Any CPU
+		{95279469-5A3E-42E6-993C-6A403586C86E}.Release|x64.Build.0 = Release|Any CPU
+		{95279469-5A3E-42E6-993C-6A403586C86E}.Release|x86.ActiveCfg = Release|Any CPU
+		{95279469-5A3E-42E6-993C-6A403586C86E}.Release|x86.Build.0 = Release|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Debug|x64.Build.0 = Debug|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Debug|x86.Build.0 = Debug|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Release|x64.ActiveCfg = Release|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Release|x64.Build.0 = Release|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Release|x86.ActiveCfg = Release|Any CPU
+		{19E962B8-6CBC-4A4A-AA17-89E6F54DD83D}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- Replaces the old Omae online-sharing feature with a "Cloud Documents" panel backed by the RunnersPoint Character Document Storage API: OAuth2/PKCE login plus a working apiToken bearer-token login (the real server only implements the latter today), list/push/download/archive for the user's own documents, and browse/download/push for documents explicitly shared with the user (per-document grants, not a public marketplace).
- Handles the API's async quarantine/validation pipeline, ETag optimistic concurrency, idempotency keys, Digest-verified downloads, and the real server's validationState vocabulary and document-type/format capability registry.
- The RunnersPoint API base URL is configurable (Options > General), defaulting to the local dev server's actual `/api/v1` route prefix.
- Adds a `Perception (Astral)` metaskill and reworks the "Improved Sense" adept power to pick a real cyberware/bioware/gear sense item and apply its actual bonus (with a houserule-controlled full-rating option and cross-item `<forbidden>` exclusivity), plus a full drug-taking/crashing/addiction-reminder mechanic.

## Test plan
- [x] `dotnet build ChummerGenSR4.sln -c Debug` — 0 errors across all commits in this branch
- [x] Manual: log in via API token against a running RunnersPoint dev server, push/download/archive a character, and browse a document shared by another account
- [ ] Manual: verify Improved Sense power selection and drug-taking flow in a live character

🤖 Generated with [Claude Code](https://claude.com/claude-code)